### PR TITLE
OPR-101 reduce size of PDF

### DIFF
--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/PageEventHandler.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/PageEventHandler.java
@@ -23,6 +23,8 @@ class PageEventHandler implements IEventHandler {
     private final Footer footer;
     @NotNull
     private final Header header;
+    @NotNull
+    private final SidePanel sidePanel;
 
     private boolean fullSidebar;
 
@@ -32,11 +34,11 @@ class PageEventHandler implements IEventHandler {
 
     private PdfOutline outline = null;
 
-    PageEventHandler(@NotNull final PatientReport patientReport) {
+    PageEventHandler(@NotNull final PatientReport patientReport, @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
-
-        this.header = new Header(patientReport.logoCompanyPath());
-        this.footer = new Footer();
+        this.sidePanel = new SidePanel(reportResources);
+        this.header = new Header(patientReport.logoCompanyPath(), reportResources);
+        this.footer = new Footer(reportResources);
     }
 
     @Override
@@ -51,8 +53,7 @@ class PageEventHandler implements IEventHandler {
 
                 createChapterBookmark(documentEvent.getDocument(), chapterTitle);
             }
-
-            SidePanel.renderSidePatientReport(page, patientReport, fullSidebar);
+            sidePanel.renderSidePatientReport(page, patientReport, fullSidebar);
             footer.renderFooter(page, patientReport.qsFormNumber(), !fullSidebar);
         }
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/PageEventHandlerPanel.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/PageEventHandlerPanel.java
@@ -19,24 +19,21 @@ class PageEventHandlerPanel implements IEventHandler {
     @NotNull
     private final PanelReport patientReport;
 
-    @NotNull
     private final Footer footer;
-    @NotNull
     private final Header header;
-
+    private final SidePanel sidePanel;
     private boolean fullSidebar;
-
     private String chapterTitle = "Undefined";
     private String pdfTitle = "Undefined";
     private boolean firstPageOfChapter = true;
 
     private PdfOutline outline = null;
 
-    PageEventHandlerPanel(@NotNull final PanelReport patientReport) {
+    PageEventHandlerPanel(@NotNull final PanelReport patientReport, @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
-
-        this.header = new Header(patientReport.logoCompanyPath());
-        this.footer = new Footer();
+        this.header = new Header(patientReport.logoCompanyPath(), reportResources);
+        this.footer = new Footer(reportResources);
+        this.sidePanel = new SidePanel(reportResources);
     }
 
     @Override
@@ -51,8 +48,7 @@ class PageEventHandlerPanel implements IEventHandler {
 
                 createChapterBookmark(documentEvent.getDocument(), chapterTitle);
             }
-
-            SidePanel.renderSidePanelPanelReport(page, patientReport, fullSidebar);
+            sidePanel.renderSidePanelPanelReport(page, patientReport, fullSidebar);
             footer.renderFooter(page, patientReport.qsFormNumber(), !fullSidebar);
         }
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/ReportResources.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/ReportResources.java
@@ -1,10 +1,5 @@
 package com.hartwig.oncoact.patientreporter.cfreport;
 
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
-
 import com.hartwig.oncoact.patientreporter.PatientReporterApplication;
 import com.itextpdf.io.font.FontProgram;
 import com.itextpdf.io.font.FontProgramFactory;
@@ -13,8 +8,12 @@ import com.itextpdf.kernel.colors.DeviceRgb;
 import com.itextpdf.kernel.font.PdfFont;
 import com.itextpdf.kernel.font.PdfFontFactory;
 import com.itextpdf.layout.Style;
-
 import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public final class ReportResources {
 
@@ -63,8 +62,24 @@ public final class ReportResources {
 
     public static final float BODY_TEXT_LEADING = 10F;
 
+    private final PdfFont fontRegular;
+    private final PdfFont fontBold;
+    private final PdfFont fontIcon;
+
+    private ReportResources(@NotNull PdfFont fontRegular, @NotNull PdfFont fontBold, @NotNull PdfFont fontIcon) {
+        this.fontRegular = fontRegular;
+        this.fontBold = fontBold;
+        this.fontIcon = fontIcon;
+    }
+
+    public static ReportResources create() {
+        return new ReportResources(createFontFromProgram(loadFontProgram(FONT_REGULAR_PATH)),
+                createFontFromProgram(loadFontProgram(FONT_BOLD_PATH)),
+                createFontFromProgram(loadFontProgram(ICON_FONT_PATH)));
+    }
+
     public static float maxPointSizeForWidth(@NotNull PdfFont font, float initialFontSize, float minFontSize, @NotNull String text,
-            float maxWidth) {
+                                             float maxWidth) {
         float fontIncrement = 0.1f;
 
         float fontSize = initialFontSize;
@@ -84,116 +99,117 @@ public final class ReportResources {
     }
 
     @NotNull
-    public static PdfFont fontRegular() {
+    public PdfFont fontRegular() {
         // Cannot be created statically as every PDF needs their own private font objects.
-        return createFontFromProgram(loadFontProgram(FONT_REGULAR_PATH));
+        return fontRegular;
     }
 
     @NotNull
-    public static PdfFont fontBold() {
+    public PdfFont fontBold() {
         // Cannot be created statically as every PDF needs their own private font objects.
-        return createFontFromProgram(loadFontProgram(FONT_BOLD_PATH));
+        return fontBold;
     }
 
     @NotNull
-    public static PdfFont iconFont() {
+    public PdfFont iconFont() {
         // Cannot be created statically as every PDF needs their own private font objects.
-        return createFontFromProgram(loadFontProgram(ICON_FONT_PATH));
+        return fontIcon;
     }
 
-    public static Style responseStyle() {
+
+    public Style responseStyle() {
         return new Style().setFont(fontBold()).setFontSize(8).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style resistantStyle() {
+    public Style resistantStyle() {
         return new Style().setFont(fontBold()).setFontSize(8).setFontColor(ReportResources.PALETTE_RED);
     }
 
-    public static Style predictedStyle() {
+    public Style predictedStyle() {
         return new Style().setFont(fontBold()).setFontSize(8).setFontColor(ReportResources.PALETTE_VIOLET);
     }
 
-    public static Style chapterTitleStyle() {
+    public Style chapterTitleStyle() {
         return new Style().setFont(fontBold()).setFontSize(16).setFontColor(ReportResources.PALETTE_BLUE).setMarginTop(0);
     }
 
-    public static Style sectionTitleStyle() {
+    public Style sectionTitleStyle() {
         return new Style().setFont(fontBold()).setFontSize(11).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style sectionSubTitleStyle() {
+    public Style sectionSubTitleStyle() {
         return new Style().setFont(fontRegular()).setFontSize(8).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style tableHeaderStyle() {
+    public Style tableHeaderStyle() {
         return new Style().setFont(fontRegular()).setFontSize(7).setFontColor(ReportResources.PALETTE_MID_GREY);
     }
 
-    public static Style tableContentStyle() {
+    public Style tableContentStyle() {
         return new Style().setFont(fontRegular()).setFontSize(8).setFontColor(ReportResources.PALETTE_DARK_GREY);
     }
 
-    public static Style bodyTextStyle() {
+    public Style bodyTextStyle() {
         return new Style().setFont(fontRegular()).setFontSize(8).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style smallBodyHeadingStyle() {
+    public Style smallBodyHeadingStyle() {
         return new Style().setFont(fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style smallBodyHeadingDisclaimerStyle() {
+    public Style smallBodyHeadingDisclaimerStyle() {
         return new Style().setFont(fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_RED);
     }
 
-    public static Style smallBodyTextStyle() {
+    public Style smallBodyTextStyle() {
         return new Style().setFont(fontRegular()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style smallBodyTextStyleRed() {
+    public Style smallBodyTextStyleRed() {
         return new Style().setFont(fontRegular()).setFontSize(7).setFontColor(ReportResources.PALETTE_RED);
     }
 
-    public static Style smallBodyBoldTextStyle() {
+    public Style smallBodyBoldTextStyle() {
         return new Style().setFont(fontBold()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style subTextStyle() {
+    public Style subTextStyle() {
         return new Style().setFont(fontRegular()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style subTextSmallStyle() {
+    public Style subTextSmallStyle() {
         return new Style().setFont(fontRegular()).setFontSize(5).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style subTextBoldStyle() {
+    public Style subTextBoldStyle() {
         return new Style().setFont(fontBold()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLACK);
     }
 
-    public static Style dataHighlightStyle() {
+    public Style dataHighlightStyle() {
         return new Style().setFont(fontBold()).setFontSize(11).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style dataHighlightNaStyle() {
+    public Style dataHighlightNaStyle() {
         return new Style().setFont(fontBold()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style pageNumberStyle() {
+    public Style pageNumberStyle() {
         return new Style().setFont(fontBold()).setFontSize(8).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style sidePanelLabelStyle() {
+    public Style sidePanelLabelStyle() {
         return new Style().setFont(fontBold()).setFontSize(7).setFontColor(ReportResources.PALETTE_WHITE);
     }
 
-    public static Style sidePanelValueStyle() {
+    public Style sidePanelValueStyle() {
         return new Style().setFont(fontBold()).setFontSize(11).setFontColor(ReportResources.PALETTE_WHITE);
     }
 
-    public static Style dataHighlightLinksStyle() {
+    public Style dataHighlightLinksStyle() {
         return new Style().setFont(fontRegular()).setFontSize(8).setFontColor(ReportResources.PALETTE_BLUE);
     }
 
-    public static Style urlStyle() {
+    public Style urlStyle() {
         return new Style().setFont(fontRegular()).setFontSize(7).setFontColor(ReportResources.PALETTE_BLUE);
     }
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/CircosChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/CircosChapter.java
@@ -24,9 +24,13 @@ public class CircosChapter implements ReportChapter {
 
     @NotNull
     private final AnalysedPatientReport patientReport;
+    @NotNull
+    private final ReportResources reportResources;
 
-    public CircosChapter(@NotNull final AnalysedPatientReport patientReport) {
+    public CircosChapter(@NotNull final AnalysedPatientReport patientReport,
+                         @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -98,10 +102,10 @@ public class CircosChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String boldPart, @NotNull String regularPart) {
-        return new Paragraph(boldPart).addStyle(ReportResources.subTextBoldStyle())
+    private Paragraph createContentParagraph(@NotNull String boldPart, @NotNull String regularPart) {
+        return new Paragraph(boldPart).addStyle(reportResources.subTextBoldStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(regularPart).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(regularPart).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceFunctions.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceFunctions.java
@@ -31,7 +31,14 @@ import org.jetbrains.annotations.NotNull;
 
 public class ClinicalEvidenceFunctions {
 
-    private ClinicalEvidenceFunctions() {
+    private final ReportResources reportResources;
+    private final TableUtil tableUtil;
+    private final EvidenceItems evidenceItems;
+
+    public ClinicalEvidenceFunctions(ReportResources reportResources) {
+        this.reportResources = reportResources;
+        this.tableUtil = new TableUtil(reportResources);
+        this.evidenceItems = new EvidenceItems(reportResources);
     }
 
     private static final String TREATMENT_DELIMITER = " + ";
@@ -81,12 +88,12 @@ public class ClinicalEvidenceFunctions {
     }
 
     @NotNull
-    public static Table createTreatmentTable(@NotNull String title, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
+    public Table createTreatmentTable(@NotNull String title, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
             float contentWidth) {
         Table treatmentTable = TableUtil.createReportContentTable(new float[] { 25, 120, 80, 25, 40, 120, 60 },
-                new Cell[] { TableUtil.createHeaderCell("Treatment", 2), TableUtil.createHeaderCell("Match", 1),
-                        TableUtil.createHeaderCell("Level", 1), TableUtil.createHeaderCell("Response", 1),
-                        TableUtil.createHeaderCell("Genomic event", 1), TableUtil.createHeaderCell("Evidence links", 1) },
+                new Cell[] { tableUtil.createHeaderCell("Treatment", 2), tableUtil.createHeaderCell("Match", 1),
+                        tableUtil.createHeaderCell("Level", 1), tableUtil.createHeaderCell("Response", 1),
+                        tableUtil.createHeaderCell("Genomic event", 1), tableUtil.createHeaderCell("Evidence links", 1) },
                 contentWidth);
 
         treatmentTable = addDataIntoTable(treatmentTable, treatmentMap, title, "evidence");
@@ -94,11 +101,11 @@ public class ClinicalEvidenceFunctions {
     }
 
     @NotNull
-    public static Table createTrialTable(@NotNull String title, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
+    public Table createTrialTable(@NotNull String title, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
             float contentWidth) {
         Table treatmentTable = TableUtil.createReportContentTable(new float[] { 20, 170, 80, 170 },
-                new Cell[] { TableUtil.createHeaderCell("Trial", 2), TableUtil.createHeaderCell("Match", 1),
-                        TableUtil.createHeaderCell("Genomic event", 1) },
+                new Cell[] { tableUtil.createHeaderCell("Trial", 2), tableUtil.createHeaderCell("Match", 1),
+                        tableUtil.createHeaderCell("Genomic event", 1) },
                 contentWidth);
 
         treatmentTable = addDataIntoTable(treatmentTable, treatmentMap, title, "trial");
@@ -106,7 +113,7 @@ public class ClinicalEvidenceFunctions {
     }
 
     @NotNull
-    private static Table addDataIntoTable(@NotNull Table treatmentTable, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
+    private Table addDataIntoTable(@NotNull Table treatmentTable, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
             @NotNull String title, @NotNull String evidenceType) {
         boolean hasEvidence = false;
         for (EvidenceLevel level : EvidenceLevel.values()) {
@@ -116,31 +123,31 @@ public class ClinicalEvidenceFunctions {
         }
 
         if (hasEvidence) {
-            return TableUtil.createWrappingReportTable(title, null, treatmentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+            return tableUtil.createWrappingReportTable(title, null, treatmentTable, TableUtil.TABLE_BOTTOM_MARGIN);
         } else {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
     }
 
     @NotNull
-    private static Paragraph createTreatmentIcons(@NotNull String allDrugs) {
+    private Paragraph createTreatmentIcons(@NotNull String allDrugs) {
         String[] drugs = allDrugs.split(Pattern.quote(TREATMENT_DELIMITER));
         Paragraph p = new Paragraph();
         for (String drug : drugs) {
-            p.add(Icon.createTreatmentIcon(drug.trim()));
+            p.add(Icon.createTreatmentIcon(reportResources, drug.trim()));
         }
         return p;
     }
 
-    private static boolean addEvidenceWithMaxLevel(@NotNull Table table, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
+    private boolean addEvidenceWithMaxLevel(@NotNull Table table, @NotNull Map<String, List<ProtectEvidence>> treatmentMap,
             @NotNull EvidenceLevel allowedHighestLevel, @NotNull String evidenceType) {
         Set<String> sortedTreatments = Sets.newTreeSet(treatmentMap.keySet());
         boolean hasEvidence = false;
         for (String treatment : sortedTreatments) {
             List<ProtectEvidence> evidences = treatmentMap.get(treatment);
             if (allowedHighestLevel == highestEvidence(treatmentMap.get(treatment))) {
-                table.addCell(TableUtil.createContentCell(createTreatmentIcons(treatment)).setVerticalAlignment(VerticalAlignment.TOP));
-                table.addCell(TableUtil.createContentCell(treatment));
+                table.addCell(tableUtil.createContentCell(createTreatmentIcons(treatment)).setVerticalAlignment(VerticalAlignment.TOP));
+                table.addCell(tableUtil.createContentCell(treatment));
 
                 Table typeTable = new Table(new float[] { 1 });
                 Table levelTable = new Table(new float[] { 1 });
@@ -150,7 +157,7 @@ public class ClinicalEvidenceFunctions {
                 Table linksTable = new Table(new float[] { 1 });
 
                 for (ProtectEvidence responsive : sort(evidences)) {
-                    Cell cellGenomic = TableUtil.createTransparentCell(display(responsive));
+                    Cell cellGenomic = tableUtil.createTransparentCell(display(responsive));
 
                     Map<String, String> sourceUrls = Maps.newHashMap();
                     Set<String> evidenceUrls = Sets.newHashSet();
@@ -166,26 +173,26 @@ public class ClinicalEvidenceFunctions {
                     }
 
                     Cell cellType;
-                    cellType = TableUtil.createTransparentCell(EvidenceItems.createLinksSource(sourceUrls));
+                    cellType = tableUtil.createTransparentCell(evidenceItems.createLinksSource(sourceUrls));
                     typeTable.addCell(cellType);
 
                     Cell cellLevel;
-                    Cell cellPredicted = TableUtil.createTransparentCell(Strings.EMPTY);
-                    Cell cellResistant = TableUtil.createTransparentCell(Strings.EMPTY);
+                    Cell cellPredicted = tableUtil.createTransparentCell(Strings.EMPTY);
+                    Cell cellResistant = tableUtil.createTransparentCell(Strings.EMPTY);
                     if (!evidenceType.equals("trial")) {
                         if (PREDICTED.contains(responsive.direction())) {
-                            cellPredicted = TableUtil.createTransparentCell(PREDICTED_SYMBOL).addStyle(ReportResources.predictedStyle());
+                            cellPredicted = tableUtil.createTransparentCell(PREDICTED_SYMBOL).addStyle(reportResources.predictedStyle());
                         }
 
                         if (RESISTANT_DIRECTIONS.contains(responsive.direction())) {
-                            cellResistant = TableUtil.createTransparentCell(RESISTANT_SYMBOL).addStyle(ReportResources.resistantStyle());
+                            cellResistant = tableUtil.createTransparentCell(RESISTANT_SYMBOL).addStyle(reportResources.resistantStyle());
                         }
 
                         if (RESPONSE_DIRECTIONS.contains(responsive.direction())) {
-                            cellResistant = TableUtil.createTransparentCell(RESPONSE_SYMBOL).addStyle(ReportResources.responseStyle());
+                            cellResistant = tableUtil.createTransparentCell(RESPONSE_SYMBOL).addStyle(reportResources.responseStyle());
                         }
 
-                        cellLevel = TableUtil.createTransparentCell(new Paragraph(Icon.createLevelIcon(responsive.level().name())));
+                        cellLevel = tableUtil.createTransparentCell(new Paragraph(Icon.createLevelIcon(reportResources, responsive.level().name())));
 
                         levelTable.addCell(cellLevel);
                         responseTable.addCell(cellResistant);
@@ -193,9 +200,9 @@ public class ClinicalEvidenceFunctions {
                     }
                     responsiveTable.addCell(cellGenomic);
 
-                    Cell publications = TableUtil.createTransparentCell(Strings.EMPTY);
+                    Cell publications = tableUtil.createTransparentCell(Strings.EMPTY);
                     if (evidenceType.equals("evidence")) {
-                        publications = TableUtil.createTransparentCell(EvidenceItems.createLinksPublications(evidenceUrls));
+                        publications = tableUtil.createTransparentCell(evidenceItems.createLinksPublications(evidenceUrls));
                         linksTable.addCell(publications);
                     } else {
                         linksTable.addCell(publications);
@@ -203,14 +210,14 @@ public class ClinicalEvidenceFunctions {
                 }
 
                 if (evidenceType.equals("evidence")) {
-                    table.addCell(TableUtil.createContentCell(typeTable));
-                    table.addCell(TableUtil.createContentCell(levelTable));
-                    table.addCell(TableUtil.createContentCell(responseTable));
-                    table.addCell(TableUtil.createContentCell(responsiveTable));
-                    table.addCell(TableUtil.createContentCell(linksTable));
+                    table.addCell(tableUtil.createContentCell(typeTable));
+                    table.addCell(tableUtil.createContentCell(levelTable));
+                    table.addCell(tableUtil.createContentCell(responseTable));
+                    table.addCell(tableUtil.createContentCell(responsiveTable));
+                    table.addCell(tableUtil.createContentCell(linksTable));
                 } else {
-                    table.addCell(TableUtil.createContentCell(typeTable));
-                    table.addCell(TableUtil.createContentCell(responsiveTable));
+                    table.addCell(tableUtil.createContentCell(typeTable));
+                    table.addCell(tableUtil.createContentCell(responsiveTable));
                 }
 
                 hasEvidence = true;
@@ -281,51 +288,51 @@ public class ClinicalEvidenceFunctions {
     }
 
     @NotNull
-    public static Paragraph noteGlossaryTerms() {
-        return new Paragraph("The symbol ( ").add(new Text(RESPONSE_SYMBOL).addStyle(ReportResources.responseStyle()))
+    public Paragraph noteGlossaryTerms() {
+        return new Paragraph("The symbol ( ").add(new Text(RESPONSE_SYMBOL).addStyle(reportResources.responseStyle()))
                 .add(" ) means that the evidence is responsive. The symbol ( ")
-                .add(new Text(RESISTANT_SYMBOL).addStyle(ReportResources.resistantStyle()))
+                .add(new Text(RESISTANT_SYMBOL).addStyle(reportResources.resistantStyle()))
                 .add(" ) means that the evidence is resistant. The abbreviation ( ")
-                .add(new Text(PREDICTED_SYMBOL).addStyle(ReportResources.predictedStyle()))
+                .add(new Text(PREDICTED_SYMBOL).addStyle(reportResources.predictedStyle()))
                 .add(" mentioned after the level of evidence) indicates the evidence is predicted "
                         + "responsive/resistent. More details about CKB can be found in their")
-                .addStyle(ReportResources.subTextStyle())
+                .addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(" Glossary Of Terms").addStyle(ReportResources.urlStyle())
+                .add(new Text(" Glossary Of Terms").addStyle(reportResources.urlStyle())
                         .setAction(PdfAction.createURI("https://ckbhome.jax.org/about/glossaryOfTerms")))
                 .add(".")
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    public static Paragraph noteEvidence() {
+    public Paragraph noteEvidence() {
         return new Paragraph().setFixedLeading(ReportResources.BODY_TEXT_LEADING)
                 .add("The Clinical Knowledgebase (CKB) is used to annotate variants of all types with clinical evidence. "
                         + "Only treatment associated evidence with evidence levels ( \n( ")
-                .add(Icon.createIcon(Icon.IconType.LEVEL_A))
+                .add(Icon.createIcon(reportResources, Icon.IconType.LEVEL_A))
                 .add(" FDA approved therapy and/or guidelines; ")
-                .add(Icon.createIcon(Icon.IconType.LEVEL_B))
+                .add(Icon.createIcon(reportResources, Icon.IconType.LEVEL_B))
                 .add(" late clinical trials; ")
-                .add(Icon.createIcon(Icon.IconType.LEVEL_C))
+                .add(Icon.createIcon(reportResources, Icon.IconType.LEVEL_C))
                 .add(" early clinical trials) can be reported. Potential evidence items with evidence level  \n( ")
-                .add(Icon.createIcon(Icon.IconType.LEVEL_D))
+                .add(Icon.createIcon(reportResources, Icon.IconType.LEVEL_D))
                 .add(" case reports and preclinical evidence) are not reported.")
-                .addStyle(ReportResources.subTextStyle());
+                .addStyle(reportResources.subTextStyle());
     }
 
     @NotNull
-    public static Paragraph noteEvidenceMatching() {
+    public Paragraph noteEvidenceMatching() {
         return new Paragraph().setFixedLeading(ReportResources.BODY_TEXT_LEADING)
                 .add("If the evidence matched is based on a mutation, but this is not a hotspot, evidence should be interpreted with "
                         + "extra caution. \n")
-                .addStyle(ReportResources.subTextStyle())
+                .addStyle(reportResources.subTextStyle())
                 .add("If a genomic event that results in an amplification is found, evidence that corresponds with ‘overexpression’"
                         + " of the gene is also matched. The same rule applies for deletions and underexpression.\n")
-                .addStyle(ReportResources.subTextStyle());
+                .addStyle(reportResources.subTextStyle());
     }
 
     @NotNull
-    public static Paragraph note(@NotNull String message) {
-        return new Paragraph(message).addStyle(ReportResources.subTextStyle());
+    public Paragraph note(@NotNull String message) {
+        return new Paragraph(message).addStyle(reportResources.subTextStyle());
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceOffLabelChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceOffLabelChapter.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.hartwig.oncoact.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.oncoact.patientreporter.algo.GenomicAnalysis;
+import com.hartwig.oncoact.patientreporter.cfreport.ReportResources;
 import com.hartwig.oncoact.patientreporter.cfreport.chapters.ReportChapter;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.itextpdf.layout.Document;
@@ -29,8 +30,12 @@ public class ClinicalEvidenceOffLabelChapter implements ReportChapter {
     @NotNull
     private final AnalysedPatientReport report;
 
-    public ClinicalEvidenceOffLabelChapter(@NotNull final AnalysedPatientReport report) {
+    @NotNull
+    private final ClinicalEvidenceFunctions clinicalEvidenceFunctions;
+
+    public ClinicalEvidenceOffLabelChapter(@NotNull final AnalysedPatientReport report, @NotNull final ReportResources reportResources) {
         this.report = report;
+        this.clinicalEvidenceFunctions = new ClinicalEvidenceFunctions(reportResources);
     }
 
     @Override
@@ -38,9 +43,9 @@ public class ClinicalEvidenceOffLabelChapter implements ReportChapter {
         GenomicAnalysis analysis = report.genomicAnalysis();
         List<ProtectEvidence> reportedOffLabel = analysis.offLabelEvidence();
         addTreatmentSection(document, "Evidence on other tumor types", reportedOffLabel);
-        document.add(ClinicalEvidenceFunctions.noteEvidence());
-        document.add(ClinicalEvidenceFunctions.noteGlossaryTerms());
-        document.add(ClinicalEvidenceFunctions.noteEvidenceMatching());
+        document.add(clinicalEvidenceFunctions.noteEvidence());
+        document.add(clinicalEvidenceFunctions.noteGlossaryTerms());
+        document.add(clinicalEvidenceFunctions.noteEvidenceMatching());
     }
 
     private void addTreatmentSection(@NotNull Document document, @NotNull String header, @NotNull List<ProtectEvidence> evidences) {
@@ -48,6 +53,6 @@ public class ClinicalEvidenceOffLabelChapter implements ReportChapter {
         boolean flagGermline = report.lamaPatientData().getReportSettings().getFlagGermlineOnReport();
         Map<String, List<ProtectEvidence>> offLabelTreatments =
                 ClinicalEvidenceFunctions.buildTreatmentMap(evidences, flagGermline, requireOnLabel);
-        document.add(ClinicalEvidenceFunctions.createTreatmentTable(header, offLabelTreatments, contentWidth()));
+        document.add(clinicalEvidenceFunctions.createTreatmentTable(header, offLabelTreatments, contentWidth()));
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceOnLabelChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ClinicalEvidenceOnLabelChapter.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.hartwig.oncoact.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.oncoact.patientreporter.algo.GenomicAnalysis;
+import com.hartwig.oncoact.patientreporter.cfreport.ReportResources;
 import com.hartwig.oncoact.patientreporter.cfreport.chapters.ReportChapter;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.itextpdf.layout.Document;
@@ -13,6 +14,8 @@ import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 
 public class ClinicalEvidenceOnLabelChapter implements ReportChapter {
+
+    private final ClinicalEvidenceFunctions clinicalEvidenceFunctions;
 
     @Override
     @NotNull
@@ -29,8 +32,10 @@ public class ClinicalEvidenceOnLabelChapter implements ReportChapter {
     @NotNull
     private final AnalysedPatientReport report;
 
-    public ClinicalEvidenceOnLabelChapter(@NotNull final AnalysedPatientReport report) {
+    public ClinicalEvidenceOnLabelChapter(@NotNull final AnalysedPatientReport report,
+                                          @NotNull final ReportResources reportResources) {
         this.report = report;
+        clinicalEvidenceFunctions = new ClinicalEvidenceFunctions(reportResources);
     }
 
     @Override
@@ -42,14 +47,15 @@ public class ClinicalEvidenceOnLabelChapter implements ReportChapter {
 
         List<ProtectEvidence> reportedStudies = analysis.clinicalTrials();
         addTrialSection(document, "Tumor type specific clinical trials (NL)", reportedStudies);
-        document.add(ClinicalEvidenceFunctions.note("Potential eligibility for DRUP is dependent on tumor type details therefore "
+
+        document.add(clinicalEvidenceFunctions.note("Potential eligibility for DRUP is dependent on tumor type details therefore "
                 + "certain tumor types may not be eligible for the DRUP.\n"));
-        document.add(ClinicalEvidenceFunctions.note("The iClusion knowledgebase is used to annotate DNA aberrations for potential "
+        document.add(clinicalEvidenceFunctions.note("The iClusion knowledgebase is used to annotate DNA aberrations for potential "
                 + "clinical study eligibility. Please note clinical study eligibility depends on multiple patient and tumor "
                 + "characteristics of which only the DNA aberrations are considered in this report. \n"));
-        document.add(ClinicalEvidenceFunctions.noteEvidence());
-        document.add(ClinicalEvidenceFunctions.noteGlossaryTerms());
-        document.add(ClinicalEvidenceFunctions.noteEvidenceMatching());
+        document.add(clinicalEvidenceFunctions.noteEvidence());
+        document.add(clinicalEvidenceFunctions.noteGlossaryTerms());
+        document.add(clinicalEvidenceFunctions.noteEvidenceMatching());
     }
 
     private void addTreatmentSection(@NotNull Document document, @NotNull String header, @NotNull List<ProtectEvidence> evidences) {
@@ -58,7 +64,7 @@ public class ClinicalEvidenceOnLabelChapter implements ReportChapter {
 
         Map<String, List<ProtectEvidence>> onLabelTreatments =
                 ClinicalEvidenceFunctions.buildTreatmentMap(evidences, flagGermline, requireOnLabel);
-        document.add(ClinicalEvidenceFunctions.createTreatmentTable(header, onLabelTreatments, contentWidth()));
+        document.add(clinicalEvidenceFunctions.createTreatmentTable(header, onLabelTreatments, contentWidth()));
     }
 
     private void addTrialSection(@NotNull Document document, @NotNull String header, @NotNull List<ProtectEvidence> evidences) {
@@ -67,6 +73,6 @@ public class ClinicalEvidenceOnLabelChapter implements ReportChapter {
 
         Map<String, List<ProtectEvidence>> onLabelTreatments =
                 ClinicalEvidenceFunctions.buildTreatmentMap(evidences, flagGermline, requireOnLabel);
-        document.add(ClinicalEvidenceFunctions.createTrialTable(header, onLabelTreatments, contentWidth()));
+        document.add(clinicalEvidenceFunctions.createTrialTable(header, onLabelTreatments, contentWidth()));
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/DetailsAndDisclaimerChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/DetailsAndDisclaimerChapter.java
@@ -1,5 +1,6 @@
 package com.hartwig.oncoact.patientreporter.cfreport.chapters.analysed;
 
+import com.hartwig.lama.client.model.Report;
 import com.hartwig.oncoact.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.oncoact.patientreporter.cfreport.ReportResources;
 import com.hartwig.oncoact.patientreporter.cfreport.chapters.ReportChapter;
@@ -23,9 +24,13 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
 
     @NotNull
     private final AnalysedPatientReport patientReport;
+    @NotNull
+    private final ReportResources reportResources;
 
-    public DetailsAndDisclaimerChapter(@NotNull AnalysedPatientReport patientReport) {
+    public DetailsAndDisclaimerChapter(@NotNull AnalysedPatientReport patientReport,
+                                       @NotNull ReportResources reportResources) {
         this.patientReport = patientReport;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -54,15 +59,16 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
         table.addCell(TableUtil.createLayoutCell().add(createDisclaimerDiv(patientReport)));
         reportDocument.add(table);
 
-        reportDocument.add(ReportSignature.createSignatureDiv(patientReport.logoRVAPath(), patientReport.signaturePath()));
-        reportDocument.add(ReportSignature.createEndOfReportIndication());
+        ReportSignature reportSignature = ReportSignature.create(reportResources);
+        reportDocument.add(reportSignature.createSignatureDiv(patientReport.logoRVAPath(), patientReport.signaturePath()));
+        reportDocument.add(reportSignature.createEndOfReportIndication());
     }
 
     @NotNull
-    private static Div createSampleDetailsDiv(@NotNull AnalysedPatientReport patientReport) {
+    private Div createSampleDetailsDiv(@NotNull AnalysedPatientReport patientReport) {
         Div div = new Div();
 
-        div.add(new Paragraph("Sample details").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Sample details").addStyle(reportResources.smallBodyHeadingStyle()));
 
         div.add(createContentParagraph("The samples have been sequenced at ", ReportResources.HARTWIG_ADDRESS));
         div.add(createContentParagraph("The samples have been analyzed by Next Generation Sequencing using Whole Genome Sequencing"));
@@ -104,11 +110,11 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createDisclaimerDiv(@NotNull AnalysedPatientReport patientReport) {
+    private Div createDisclaimerDiv(@NotNull AnalysedPatientReport patientReport) {
         String pipelineVersion = patientReport.pipelineVersion() == null ? "No pipeline version is known" : patientReport.pipelineVersion();
         Div div = new Div();
 
-        div.add(new Paragraph("Disclaimer").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Disclaimer").addStyle(reportResources.smallBodyHeadingStyle()));
 
         div.add(createContentParagraph("The data on which this report is based is generated "
                 + "from tests that are performed under NEN-EN-ISO/IEC-17025:2017 TESTING L633 accreditation and have passed all internal quality controls."));
@@ -138,7 +144,7 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createContentDivWithLink(@NotNull String string1, @NotNull String string2, @NotNull String link) {
+    private Div createContentDivWithLink(@NotNull String string1, @NotNull String string2, @NotNull String link) {
         Div div = new Div();
 
         div.add(createParaGraphWithLink(string1, string2, link));
@@ -146,15 +152,15 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createParaGraphWithLink(@NotNull String string1, @NotNull String string2, @NotNull String link) {
-        return new Paragraph(string1).addStyle(ReportResources.subTextStyle())
+    private Paragraph createParaGraphWithLink(@NotNull String string1, @NotNull String string2, @NotNull String link) {
+        return new Paragraph(string1).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string2).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link)))
+                .add(new Text(string2).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph generateHMFAndPathologySampleIDParagraph(@NotNull AnalysedPatientReport patientReport) {
+    private Paragraph generateHMFAndPathologySampleIDParagraph(@NotNull AnalysedPatientReport patientReport) {
         String pathologyId = patientReport.lamaPatientData().getPathologyNumber();
         String reportingId = patientReport.lamaPatientData().getReportingId();
 
@@ -176,28 +182,28 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createContentParagraphRed(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraphRed(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+    private Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
 
     @NotNull
-    private static Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
+    private Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
                                                          @NotNull String regularPart2, @NotNull String boldPart2) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .add(regularPart2)
-                .add(new Text(boldPart2).addStyle(ReportResources.smallBodyBoldTextStyle()))
+                .add(new Text(boldPart2).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ExplanationChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/ExplanationChapter.java
@@ -16,7 +16,11 @@ import org.jetbrains.annotations.NotNull;
 
 public class ExplanationChapter implements ReportChapter {
 
-    public ExplanationChapter() {
+    @NotNull
+    private final ReportResources reportResources;
+
+    public ExplanationChapter(@NotNull final ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -181,36 +185,36 @@ public class ExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createSectionTitle(@NotNull String sectionTitle) {
-        return new Paragraph(sectionTitle).addStyle(ReportResources.smallBodyHeadingStyle());
+    private Paragraph createSectionTitle(@NotNull String sectionTitle) {
+        return new Paragraph(sectionTitle).addStyle(reportResources.smallBodyHeadingStyle());
     }
 
     @NotNull
-    private static Paragraph createParaGraphWithLinkFour(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Paragraph createParaGraphWithLinkFour(@NotNull String string1, @NotNull String string2, @NotNull String string3,
             @NotNull String string4, @NotNull String link1, @NotNull String link2) {
-        return new Paragraph(string1).addStyle(ReportResources.subTextStyle())
+        return new Paragraph(string1).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string2).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link1)))
+                .add(new Text(string2).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link1)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string3).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(string3).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string4).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link2)))
+                .add(new Text(string4).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link2)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
             @NotNull String link) {
-        return new Paragraph(string1).addStyle(ReportResources.subTextStyle())
+        return new Paragraph(string1).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string2).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link)))
+                .add(new Text(string2).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string3).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(string3).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
             @NotNull String link) {
         Div div = new Div();
 
@@ -219,7 +223,7 @@ public class ExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createContentDivWithLinkFour(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Div createContentDivWithLinkFour(@NotNull String string1, @NotNull String string2, @NotNull String string3,
             @NotNull String string4, @NotNull String link1, @NotNull String link2) {
         Div div = new Div();
         div.add(createParaGraphWithLinkFour(string1, string2, string3, string4, link1, link2));
@@ -227,10 +231,10 @@ public class ExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createContentDiv(@NotNull String[] contentParagraphs) {
+    private Div createContentDiv(@NotNull String[] contentParagraphs) {
         Div div = new Div();
         for (String s : contentParagraphs) {
-            div.add(new Paragraph(s).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
+            div.add(new Paragraph(s).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
         }
         return div;
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/GenomicAlterationsChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/GenomicAlterationsChapter.java
@@ -1,21 +1,17 @@
 package com.hartwig.oncoact.patientreporter.cfreport.chapters.analysed;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.common.collect.Sets;
-import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
-import com.hartwig.oncoact.disruption.GeneDisruption;
-import com.hartwig.oncoact.hla.HlaAllelesReportingData;
-import com.hartwig.oncoact.hla.HlaReporting;
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
-import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.peach.PeachGenotype;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
 import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
+import com.hartwig.oncoact.disruption.GeneDisruption;
+import com.hartwig.oncoact.hla.HlaAllelesReportingData;
+import com.hartwig.oncoact.hla.HlaReporting;
 import com.hartwig.oncoact.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.oncoact.patientreporter.algo.GenomicAnalysis;
 import com.hartwig.oncoact.patientreporter.algo.InterpretPurpleGeneCopyNumbers;
@@ -24,17 +20,7 @@ import com.hartwig.oncoact.patientreporter.cfreport.ReportResources;
 import com.hartwig.oncoact.patientreporter.cfreport.chapters.ReportChapter;
 import com.hartwig.oncoact.patientreporter.cfreport.components.InlineBarChart;
 import com.hartwig.oncoact.patientreporter.cfreport.components.TableUtil;
-import com.hartwig.oncoact.patientreporter.cfreport.data.GainsAndLosses;
-import com.hartwig.oncoact.patientreporter.cfreport.data.GeneDisruptions;
-import com.hartwig.oncoact.patientreporter.cfreport.data.GeneFusions;
-import com.hartwig.oncoact.patientreporter.cfreport.data.GeneUtil;
-import com.hartwig.oncoact.patientreporter.cfreport.data.HLAAllele;
-import com.hartwig.oncoact.patientreporter.cfreport.data.HomozygousDisruptions;
-import com.hartwig.oncoact.patientreporter.cfreport.data.LohGenes;
-import com.hartwig.oncoact.patientreporter.cfreport.data.Pharmacogenetics;
-import com.hartwig.oncoact.patientreporter.cfreport.data.SomaticVariants;
-import com.hartwig.oncoact.patientreporter.cfreport.data.TumorPurity;
-import com.hartwig.oncoact.patientreporter.cfreport.data.ViralPresence;
+import com.hartwig.oncoact.patientreporter.cfreport.data.*;
 import com.hartwig.oncoact.util.Formats;
 import com.hartwig.oncoact.variant.ReportableVariant;
 import com.itextpdf.kernel.pdf.action.PdfAction;
@@ -44,9 +30,12 @@ import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Table;
 import com.itextpdf.layout.element.Text;
 import com.itextpdf.layout.property.TextAlignment;
-
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class GenomicAlterationsChapter implements ReportChapter {
 
@@ -56,9 +45,20 @@ public class GenomicAlterationsChapter implements ReportChapter {
     @NotNull
     private final AnalysedPatientReport patientReport;
 
+    @NotNull
+    private final ReportResources reportResources;
 
-    public GenomicAlterationsChapter(@NotNull final AnalysedPatientReport patientReport) {
+    private final TableUtil tableUtil;
+
+    private final GeneFusions geneFusions;
+
+
+    public GenomicAlterationsChapter(@NotNull final AnalysedPatientReport patientReport,
+                                     @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
+        this.reportResources = reportResources;
+        this.tableUtil = new TableUtil(reportResources);
+        this.geneFusions = new GeneFusions(reportResources);
     }
 
     @NotNull
@@ -106,7 +106,7 @@ public class GenomicAlterationsChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Table createPloidyPloidyTable(double ploidy, double purity, boolean hasReliablePurity) {
+    private Table createPloidyPloidyTable(double ploidy, double purity, boolean hasReliablePurity) {
         String title = "Tumor purity & ploidy";
 
         Table contentTable =
@@ -121,16 +121,16 @@ public class GenomicAlterationsChapter implements ReportChapter {
                 contentTable);
 
         String copyNumber = GeneUtil.copyNumberToString(ploidy, hasReliablePurity);
-        contentTable.addCell(TableUtil.createContentCell("Average tumor ploidy"));
+        contentTable.addCell(tableUtil.createContentCell("Average tumor ploidy"));
         if (copyNumber.equals(Formats.NA_STRING)) {
-            contentTable.addCell(TableUtil.createContentCell(copyNumber).setTextAlignment(TextAlignment.CENTER));
+            contentTable.addCell(tableUtil.createContentCell(copyNumber).setTextAlignment(TextAlignment.CENTER));
         } else {
-            contentTable.addCell(TableUtil.createContentCellPurityPloidy(copyNumber).setTextAlignment(TextAlignment.CENTER));
+            contentTable.addCell(tableUtil.createContentCellPurityPloidy(copyNumber).setTextAlignment(TextAlignment.CENTER));
 
         }
-        contentTable.addCell(TableUtil.createContentCell(Strings.EMPTY));
+        contentTable.addCell(tableUtil.createContentCell(Strings.EMPTY));
 
-        return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
@@ -141,159 +141,159 @@ public class GenomicAlterationsChapter implements ReportChapter {
         return chart;
     }
 
-    private static void renderTumorPurity(boolean hasReliablePurity, @NotNull String valueLabel, double value, double min, double max,
+    private void renderTumorPurity(boolean hasReliablePurity, @NotNull String valueLabel, double value, double min, double max,
                                           @NotNull Table table) {
 
         String label = "Tumor purity";
-        table.addCell(TableUtil.createContentCell(label));
+        table.addCell(tableUtil.createContentCell(label));
 
         if (hasReliablePurity) {
-            table.addCell(TableUtil.createContentCellPurityPloidy(valueLabel).setTextAlignment(TextAlignment.CENTER));
-            table.addCell(TableUtil.createContentCell(createInlineBarChart(value, min, max))
+            table.addCell(tableUtil.createContentCellPurityPloidy(valueLabel).setTextAlignment(TextAlignment.CENTER));
+            table.addCell(tableUtil.createContentCell(createInlineBarChart(value, min, max))
                     .setPadding(8)
                     .setTextAlignment(TextAlignment.CENTER));
         } else {
-            table.addCell(TableUtil.createContentCell("N/A"));
-            table.addCell(TableUtil.createContentCell(Strings.EMPTY));
+            table.addCell(tableUtil.createContentCell("N/A"));
+            table.addCell(tableUtil.createContentCell(Strings.EMPTY));
         }
     }
 
     @NotNull
-    private static Table createTumorVariantsTable(@NotNull List<ReportableVariant> reportableVariants,
+    private Table createTumorVariantsTable(@NotNull List<ReportableVariant> reportableVariants,
                                                   @NotNull Map<ReportableVariant, Boolean> notifyGermlineStatusPerVariant, boolean hasReliablePurity) {
         String title = "Tumor specific variants";
         if (reportableVariants.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table contentTable;
         if (DISPLAY_CLONAL_COLUMN) {
             contentTable = TableUtil.createReportContentTable(new float[]{60, 70, 80, 70, 60, 40, 30, 60, 60, 50, 50},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Position"),
-                            TableUtil.createHeaderCell("Variant"), TableUtil.createHeaderCell("Protein"),
-                            TableUtil.createHeaderCell("Read depth").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("tVAF").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Biallelic").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Hotspot").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Clonal").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Position"),
+                            tableUtil.createHeaderCell("Variant"), tableUtil.createHeaderCell("Protein"),
+                            tableUtil.createHeaderCell("Read depth").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("tVAF").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Biallelic").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Hotspot").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Clonal").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
                     ReportResources.CONTENT_WIDTH_WIDE);
         } else {
             contentTable = TableUtil.createReportContentTable(new float[]{60, 70, 80, 70, 60, 40, 30, 60, 60, 50},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Position"),
-                            TableUtil.createHeaderCell("Variant"), TableUtil.createHeaderCell("Protein"),
-                            TableUtil.createHeaderCell("Read depth").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("tVAF").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Biallelic").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Hotspot").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Position"),
+                            tableUtil.createHeaderCell("Variant"), tableUtil.createHeaderCell("Protein"),
+                            tableUtil.createHeaderCell("Read depth").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("tVAF").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Biallelic").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Hotspot").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
                     ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         for (ReportableVariant variant : SomaticVariants.sort(reportableVariants)) {
-            contentTable.addCell(TableUtil.createContentCell(SomaticVariants.geneDisplayString(variant,
+            contentTable.addCell(tableUtil.createContentCell(SomaticVariants.geneDisplayString(variant,
                     notifyGermlineStatusPerVariant.get(variant), variant.localPhaseSet(), variant.canonicalEffect())));
-            contentTable.addCell(TableUtil.createContentCell(variant.gDNA()));
-            contentTable.addCell(TableUtil.createContentCell(variant.canonicalHgvsCodingImpact()));
-            contentTable.addCell(TableUtil.createContentCell(variant.canonicalHgvsProteinImpact()));
-            contentTable.addCell(TableUtil.createContentCell(new Paragraph(
-                    variant.alleleReadCount() + " / ").setFont(ReportResources.fontBold())
-                    .add(new Text(String.valueOf(variant.totalReadCount())).setFont(ReportResources.fontRegular()))
+            contentTable.addCell(tableUtil.createContentCell(variant.gDNA()));
+            contentTable.addCell(tableUtil.createContentCell(variant.canonicalHgvsCodingImpact()));
+            contentTable.addCell(tableUtil.createContentCell(variant.canonicalHgvsProteinImpact()));
+            contentTable.addCell(tableUtil.createContentCell(new Paragraph(
+                    variant.alleleReadCount() + " / ").setFont(reportResources.fontBold())
+                    .add(new Text(String.valueOf(variant.totalReadCount())).setFont(reportResources.fontRegular()))
                     .setTextAlignment(TextAlignment.CENTER)));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(variant.totalCopyNumber(), hasReliablePurity))
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(variant.totalCopyNumber(), hasReliablePurity))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(SomaticVariants.tVAFString(variant.tVAF(),
+            contentTable.addCell(tableUtil.createContentCell(SomaticVariants.tVAFString(variant.tVAF(),
                     hasReliablePurity,
                     variant.totalCopyNumber())).setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(SomaticVariants.biallelicString(variant.biallelic(), hasReliablePurity))
+            contentTable.addCell(tableUtil.createContentCell(SomaticVariants.biallelicString(variant.biallelic(), hasReliablePurity))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(SomaticVariants.hotspotString(variant.hotspot()))
+            contentTable.addCell(tableUtil.createContentCell(SomaticVariants.hotspotString(variant.hotspot()))
                     .setTextAlignment(TextAlignment.CENTER));
             if (DISPLAY_CLONAL_COLUMN) {
-                contentTable.addCell(TableUtil.createContentCell(SomaticVariants.clonalString(variant.clonalLikelihood()))
+                contentTable.addCell(tableUtil.createContentCell(SomaticVariants.clonalString(variant.clonalLikelihood()))
                         .setTextAlignment(TextAlignment.CENTER));
             }
-            contentTable.addCell(TableUtil.createContentCell(variant.driverLikelihoodInterpretation().display()))
+            contentTable.addCell(tableUtil.createContentCell(variant.driverLikelihoodInterpretation().display()))
                     .setTextAlignment(TextAlignment.CENTER);
         }
 
         if (SomaticVariants.hasNotifiableGermlineVariant(notifyGermlineStatusPerVariant)) {
             contentTable.addCell(TableUtil.createLayoutCell(1, contentTable.getNumberOfColumns())
                     .add(new Paragraph("\n# Marked variant(s) are also present in the germline of the patient. Referral to a genetic "
-                            + "specialist should be advised.").addStyle(ReportResources.subTextStyle())));
+                            + "specialist should be advised.").addStyle(reportResources.subTextStyle())));
         }
 
         if (SomaticVariants.hasPhasedVariant(reportableVariants)) {
             contentTable.addCell(TableUtil.createLayoutCell(1, contentTable.getNumberOfColumns())
-                    .add(new Paragraph("\n+ Marked protein (p.) annotation is based on multiple phased variants.").addStyle(ReportResources.subTextStyle())));
+                    .add(new Paragraph("\n+ Marked protein (p.) annotation is based on multiple phased variants.").addStyle(reportResources.subTextStyle())));
         }
 
         if (SomaticVariants.hasVariantsInCis(reportableVariants)) {
             contentTable.addCell(TableUtil.createLayoutCell(1, contentTable.getNumberOfColumns())
-                    .add(new Paragraph("\n= Marked variants are present in cis").addStyle(ReportResources.subTextStyle())));
+                    .add(new Paragraph("\n= Marked variants are present in cis").addStyle(reportResources.subTextStyle())));
         }
 
-        return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createGainsAndLossesTable(@NotNull List<PurpleGainLoss> gainsAndLosses, boolean hasReliablePurity,
+    private Table createGainsAndLossesTable(@NotNull List<PurpleGainLoss> gainsAndLosses, boolean hasReliablePurity,
                                                    @NotNull List<CnPerChromosomeArmData> cnPerChromosome) {
         String title = "Tumor specific gains & losses";
         if (gainsAndLosses.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table contentTable = TableUtil.createReportContentTable(new float[]{80, 80, 100, 80, 60, 60, 150},
-                new Cell[]{TableUtil.createHeaderCell("Chromosome"), TableUtil.createHeaderCell("Region"),
-                        TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Type"), TableUtil.createHeaderCell("min copies"),
-                        TableUtil.createHeaderCell("max copies"),
-                        TableUtil.createHeaderCell("Chromosome arm copies").setTextAlignment(TextAlignment.CENTER)},
+                new Cell[]{tableUtil.createHeaderCell("Chromosome"), tableUtil.createHeaderCell("Region"),
+                        tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Type"), tableUtil.createHeaderCell("min copies"),
+                        tableUtil.createHeaderCell("max copies"),
+                        tableUtil.createHeaderCell("Chromosome arm copies").setTextAlignment(TextAlignment.CENTER)},
                 ReportResources.CONTENT_WIDTH_WIDE);
 
         List<PurpleGainLoss> sortedGainsAndLosses = GainsAndLosses.sort(gainsAndLosses);
         for (PurpleGainLoss gainLoss : sortedGainsAndLosses) {
-            contentTable.addCell(TableUtil.createContentCell(gainLoss.chromosome()));
-            contentTable.addCell(TableUtil.createContentCell(gainLoss.chromosomeBand()));
-            contentTable.addCell(TableUtil.createContentCell(gainLoss.gene()));
-            contentTable.addCell(TableUtil.createContentCell(GainsAndLosses.interpretation(gainLoss)));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(gainLoss.minCopies(), hasReliablePurity))
+            contentTable.addCell(tableUtil.createContentCell(gainLoss.chromosome()));
+            contentTable.addCell(tableUtil.createContentCell(gainLoss.chromosomeBand()));
+            contentTable.addCell(tableUtil.createContentCell(gainLoss.gene()));
+            contentTable.addCell(tableUtil.createContentCell(GainsAndLosses.interpretation(gainLoss)));
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(gainLoss.minCopies(), hasReliablePurity))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(gainLoss.maxCopies(), hasReliablePurity))
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(gainLoss.maxCopies(), hasReliablePurity))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GainsAndLosses.chromosomeArmCopyNumber(cnPerChromosome, gainLoss))
+            contentTable.addCell(tableUtil.createContentCell(GainsAndLosses.chromosomeArmCopyNumber(cnPerChromosome, gainLoss))
                     .setTextAlignment(TextAlignment.CENTER));
         }
 
-        return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createHomozygousDisruptionsTable(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
+    private Table createHomozygousDisruptionsTable(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
         String title = "Tumor specific homozygous disruptions";
         String subtitle = "Complete loss of wild type allele";
         if (homozygousDisruptions.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, subtitle, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, subtitle, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table contentTable = TableUtil.createReportContentTable(new float[]{80, 80, 100},
-                new Cell[]{TableUtil.createHeaderCell("Chromosome"), TableUtil.createHeaderCell("Region"),
-                        TableUtil.createHeaderCell("Gene")},
+                new Cell[]{tableUtil.createHeaderCell("Chromosome"), tableUtil.createHeaderCell("Region"),
+                        tableUtil.createHeaderCell("Gene")},
                 ReportResources.CONTENT_WIDTH_WIDE);
 
         for (HomozygousDisruption homozygousDisruption : HomozygousDisruptions.sort(homozygousDisruptions)) {
-            contentTable.addCell(TableUtil.createContentCell(homozygousDisruption.chromosome()));
-            contentTable.addCell(TableUtil.createContentCell(homozygousDisruption.chromosomeBand()));
-            contentTable.addCell(TableUtil.createContentCell(homozygousDisruption.gene()));
+            contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.chromosome()));
+            contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.chromosomeBand()));
+            contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.gene()));
         }
 
-        return TableUtil.createWrappingReportTable(title, subtitle, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, subtitle, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createLOHTable(@NotNull List<InterpretPurpleGeneCopyNumbers> suspectGeneCopyNumbersWithLOH, @NotNull String signature) {
+    private Table createLOHTable(@NotNull List<InterpretPurpleGeneCopyNumbers> suspectGeneCopyNumbersWithLOH, @NotNull String signature) {
         String title = Strings.EMPTY;
         if (signature.equals("HRD")) {
             title = "Interesting LOH events in case of HRD";
@@ -302,111 +302,111 @@ public class GenomicAlterationsChapter implements ReportChapter {
         }
 
         if (suspectGeneCopyNumbersWithLOH.isEmpty() || title.equals(Strings.EMPTY)) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table table = TableUtil.createReportContentTable(new float[]{1, 1, 1, 1},
-                new Cell[]{TableUtil.createHeaderCell("Location"), TableUtil.createHeaderCell("Gene"),
-                        TableUtil.createHeaderCell("Tumor minor allele copies").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Tumor copies").setTextAlignment(TextAlignment.CENTER)},
+                new Cell[]{tableUtil.createHeaderCell("Location"), tableUtil.createHeaderCell("Gene"),
+                        tableUtil.createHeaderCell("Tumor minor allele copies").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Tumor copies").setTextAlignment(TextAlignment.CENTER)},
                 ReportResources.CONTENT_WIDTH_WIDE);
 
         for (InterpretPurpleGeneCopyNumbers LOHgenes : LohGenes.sort(suspectGeneCopyNumbersWithLOH)) {
-            table.addCell(TableUtil.createContentCell(LOHgenes.chromosome() + LOHgenes.chromosomeBand()));
-            table.addCell(TableUtil.createContentCell(LOHgenes.geneName()));
-            table.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(LOHgenes.minMinorAlleleCopyNumber())).setTextAlignment(TextAlignment.CENTER));
-            table.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(LOHgenes.minCopyNumber())).setTextAlignment(TextAlignment.CENTER));
+            table.addCell(tableUtil.createContentCell(LOHgenes.chromosome() + LOHgenes.chromosomeBand()));
+            table.addCell(tableUtil.createContentCell(LOHgenes.geneName()));
+            table.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(LOHgenes.minMinorAlleleCopyNumber())).setTextAlignment(TextAlignment.CENTER));
+            table.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(LOHgenes.minCopyNumber())).setTextAlignment(TextAlignment.CENTER));
         }
 
-        return TableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createFusionsTable(@NotNull List<LinxFusion> fusions, boolean hasReliablePurity) {
+    private Table createFusionsTable(@NotNull List<LinxFusion> fusions, boolean hasReliablePurity) {
         String title = "Tumor specific gene fusions";
         if (fusions.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table contentTable = TableUtil.createReportContentTable(new float[]{80, 70, 80, 80, 40, 40, 40, 65, 40},
-                new Cell[]{TableUtil.createHeaderCell("Fusion"),
-                        TableUtil.createHeaderCell("Type").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("5' Transcript"), TableUtil.createHeaderCell("3' Transcript"),
-                        TableUtil.createHeaderCell("5' End"), TableUtil.createHeaderCell("3' Start"),
-                        TableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Phasing").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
+                new Cell[]{tableUtil.createHeaderCell("Fusion"),
+                        tableUtil.createHeaderCell("Type").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("5' Transcript"), tableUtil.createHeaderCell("3' Transcript"),
+                        tableUtil.createHeaderCell("5' End"), tableUtil.createHeaderCell("3' Start"),
+                        tableUtil.createHeaderCell("Copies").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Phasing").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
                 ReportResources.CONTENT_WIDTH_WIDE);
 
         for (LinxFusion fusion : GeneFusions.sort(fusions)) {
-            contentTable.addCell(TableUtil.createContentCell(GeneFusions.name(fusion)));
-            contentTable.addCell(TableUtil.createContentCell(GeneFusions.type(fusion)).setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(GeneFusions.fusionContentType(fusion.reportedType(), fusion.geneStart(), fusion.geneTranscriptStart()));
-            contentTable.addCell(GeneFusions.fusionContentType(fusion.reportedType(), fusion.geneEnd(), fusion.geneTranscriptEnd()));
-            contentTable.addCell(TableUtil.createContentCell(fusion.geneContextStart()));
-            contentTable.addCell(TableUtil.createContentCell(fusion.geneContextEnd()));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(fusion.junctionCopyNumber(), hasReliablePurity))
+            contentTable.addCell(tableUtil.createContentCell(GeneFusions.name(fusion)));
+            contentTable.addCell(tableUtil.createContentCell(GeneFusions.type(fusion)).setTextAlignment(TextAlignment.CENTER));
+            contentTable.addCell(geneFusions.fusionContentType(fusion.reportedType(), fusion.geneStart(), fusion.geneTranscriptStart()));
+            contentTable.addCell(geneFusions.fusionContentType(fusion.reportedType(), fusion.geneEnd(), fusion.geneTranscriptEnd()));
+            contentTable.addCell(tableUtil.createContentCell(fusion.geneContextStart()));
+            contentTable.addCell(tableUtil.createContentCell(fusion.geneContextEnd()));
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(fusion.junctionCopyNumber(), hasReliablePurity))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GeneFusions.phased(fusion)).setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GeneFusions.likelihood(fusion)).setTextAlignment(TextAlignment.CENTER));
+            contentTable.addCell(tableUtil.createContentCell(GeneFusions.phased(fusion)).setTextAlignment(TextAlignment.CENTER));
+            contentTable.addCell(tableUtil.createContentCell(GeneFusions.likelihood(fusion)).setTextAlignment(TextAlignment.CENTER));
         }
 
-        return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createDisruptionsTable(@NotNull List<GeneDisruption> disruptions, boolean hasReliablePurity) {
+    private Table createDisruptionsTable(@NotNull List<GeneDisruption> disruptions, boolean hasReliablePurity) {
         String title = "Tumor specific gene disruptions";
         if (disruptions.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         }
 
         Table contentTable = TableUtil.createReportContentTable(new float[]{60, 50, 100, 50, 80, 85, 85},
-                new Cell[]{TableUtil.createHeaderCell("Location"), TableUtil.createHeaderCell("Gene"),
-                        TableUtil.createHeaderCell("Disrupted range"),
-                        TableUtil.createHeaderCell("Type").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Cluster ID").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Disrupted copies").setTextAlignment(TextAlignment.CENTER),
-                        TableUtil.createHeaderCell("Undisrupted copies").setTextAlignment(TextAlignment.CENTER)},
+                new Cell[]{tableUtil.createHeaderCell("Location"), tableUtil.createHeaderCell("Gene"),
+                        tableUtil.createHeaderCell("Disrupted range"),
+                        tableUtil.createHeaderCell("Type").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Cluster ID").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Disrupted copies").setTextAlignment(TextAlignment.CENTER),
+                        tableUtil.createHeaderCell("Undisrupted copies").setTextAlignment(TextAlignment.CENTER)},
                 ReportResources.CONTENT_WIDTH_WIDE);
 
         for (GeneDisruption disruption : GeneDisruptions.sort(disruptions)) {
-            contentTable.addCell(TableUtil.createContentCell(disruption.location()));
-            contentTable.addCell(TableUtil.createContentCell(disruption.gene()));
-            contentTable.addCell(TableUtil.createContentCell(disruption.range()));
-            contentTable.addCell(TableUtil.createContentCell(disruption.type())).setTextAlignment(TextAlignment.CENTER);
-            contentTable.addCell(TableUtil.createContentCell(String.valueOf(disruption.clusterId()))
+            contentTable.addCell(tableUtil.createContentCell(disruption.location()));
+            contentTable.addCell(tableUtil.createContentCell(disruption.gene()));
+            contentTable.addCell(tableUtil.createContentCell(disruption.range()));
+            contentTable.addCell(tableUtil.createContentCell(disruption.type())).setTextAlignment(TextAlignment.CENTER);
+            contentTable.addCell(tableUtil.createContentCell(String.valueOf(disruption.clusterId()))
                     .setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(disruption.junctionCopyNumber(),
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(disruption.junctionCopyNumber(),
                     hasReliablePurity)).setTextAlignment(TextAlignment.CENTER));
-            contentTable.addCell(TableUtil.createContentCell(GeneUtil.roundCopyNumber(disruption.undisruptedCopyNumber(),
+            contentTable.addCell(tableUtil.createContentCell(GeneUtil.roundCopyNumber(disruption.undisruptedCopyNumber(),
                     hasReliablePurity)).setTextAlignment(TextAlignment.CENTER));
         }
-        return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createHlaTable(@NotNull HlaAllelesReportingData lilac, boolean hasReliablePurity) {
+    private Table createHlaTable(@NotNull HlaAllelesReportingData lilac, boolean hasReliablePurity) {
         String title = "HLA Alleles";
         Table table = TableUtil.createReportContentTable(new float[]{10, 10, 10, 10, 10, 10},
-                new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Germline allele"),
-                        TableUtil.createHeaderCell("Germline copies"), TableUtil.createHeaderCell("Tumor copies"),
-                        TableUtil.createHeaderCell("Number somatic mutations*"),
-                        TableUtil.createHeaderCell("Interpretation: presence in tumor")},
+                new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Germline allele"),
+                        tableUtil.createHeaderCell("Germline copies"), tableUtil.createHeaderCell("Tumor copies"),
+                        tableUtil.createHeaderCell("Number somatic mutations*"),
+                        tableUtil.createHeaderCell("Interpretation: presence in tumor")},
                 ReportResources.CONTENT_WIDTH_WIDE);
         if (!lilac.hlaQC().equals("PASS")) {
             String noConsent = "The QC of the HLA types do not meet the QC cut-offs";
-            return TableUtil.createNoConsentReportTable(title,
+            return tableUtil.createNoConsentReportTable(title,
                     noConsent,
                     TableUtil.TABLE_BOTTOM_MARGIN,
                     ReportResources.CONTENT_WIDTH_WIDE);
         } else if (lilac.hlaAllelesReporting().isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         } else {
             Set<String> sortedAlleles = Sets.newTreeSet(lilac.hlaAllelesReporting().keySet());
             for (String sortAllele : sortedAlleles) {
                 List<HlaReporting> allele = lilac.hlaAllelesReporting().get(sortAllele);
-                table.addCell(TableUtil.createContentCell(sortAllele));
+                table.addCell(tableUtil.createContentCell(sortAllele));
 
                 Table tableGermlineAllele = new Table(new float[]{1});
                 Table tableGermlineCopies = new Table(new float[]{1});
@@ -415,74 +415,74 @@ public class GenomicAlterationsChapter implements ReportChapter {
                 Table tablePresenceInTumor = new Table(new float[]{1});
 
                 for (HlaReporting hlaAlleleReporting : HLAAllele.sort(allele)) {
-                    tableGermlineAllele.addCell(TableUtil.createTransparentCell(hlaAlleleReporting.hlaAllele().germlineAllele()));
-                    tableGermlineCopies.addCell(TableUtil.createTransparentCell(GeneUtil.roundCopyNumber(hlaAlleleReporting.germlineCopies(),
+                    tableGermlineAllele.addCell(tableUtil.createTransparentCell(hlaAlleleReporting.hlaAllele().germlineAllele()));
+                    tableGermlineCopies.addCell(tableUtil.createTransparentCell(GeneUtil.roundCopyNumber(hlaAlleleReporting.germlineCopies(),
                             hasReliablePurity)));
-                    tableTumorCopies.addCell(TableUtil.createTransparentCell(GeneUtil.roundCopyNumber(hlaAlleleReporting.tumorCopies(),
+                    tableTumorCopies.addCell(tableUtil.createTransparentCell(GeneUtil.roundCopyNumber(hlaAlleleReporting.tumorCopies(),
                             hasReliablePurity)));
-                    tableSomaticMutations.addCell(TableUtil.createTransparentCell(hlaAlleleReporting.somaticMutations()));
-                    tablePresenceInTumor.addCell(TableUtil.createTransparentCell(hlaAlleleReporting.interpretation()));
+                    tableSomaticMutations.addCell(tableUtil.createTransparentCell(hlaAlleleReporting.somaticMutations()));
+                    tablePresenceInTumor.addCell(tableUtil.createTransparentCell(hlaAlleleReporting.interpretation()));
                 }
 
-                table.addCell(TableUtil.createContentCell(tableGermlineAllele));
-                table.addCell(TableUtil.createContentCell(tableGermlineCopies));
-                table.addCell(TableUtil.createContentCell(tableTumorCopies));
-                table.addCell(TableUtil.createContentCell(tableSomaticMutations));
-                table.addCell(TableUtil.createContentCell(tablePresenceInTumor));
+                table.addCell(tableUtil.createContentCell(tableGermlineAllele));
+                table.addCell(tableUtil.createContentCell(tableGermlineCopies));
+                table.addCell(tableUtil.createContentCell(tableTumorCopies));
+                table.addCell(tableUtil.createContentCell(tableSomaticMutations));
+                table.addCell(tableUtil.createContentCell(tablePresenceInTumor));
             }
         }
 
         table.addCell(TableUtil.createLayoutCell(1, table.getNumberOfColumns())
                 .add(new Paragraph("\n *When phasing is unclear the mutation will be counted in both alleles as 0.5. Copy number of"
-                        + " detected mutations can be found in the somatic variant table.").addStyle(ReportResources.subTextStyle()
+                        + " detected mutations can be found in the somatic variant table.").addStyle(reportResources.subTextStyle()
                         .setTextAlignment(TextAlignment.CENTER))));
-        return TableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createVirusTable(@NotNull List<AnnotatedVirus> viruses) {
+    private Table createVirusTable(@NotNull List<AnnotatedVirus> viruses) {
         String title = "Tumor specific viral insertions";
 
         if (viruses.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         } else {
             Table contentTable = TableUtil.createReportContentTable(new float[]{150, 160, 100, 40},
-                    new Cell[]{TableUtil.createHeaderCell("Virus"),
-                            TableUtil.createHeaderCell("Number of detected integration sites").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Viral coverage").setTextAlignment(TextAlignment.CENTER),
-                            TableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
+                    new Cell[]{tableUtil.createHeaderCell("Virus"),
+                            tableUtil.createHeaderCell("Number of detected integration sites").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Viral coverage").setTextAlignment(TextAlignment.CENTER),
+                            tableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER)},
                     ReportResources.CONTENT_WIDTH_WIDE);
 
             for (AnnotatedVirus virus : viruses) {
-                contentTable.addCell(TableUtil.createContentCell(ViralPresence.interpretVirusName(virus.name(), virus.interpretation(), virus.virusDriverLikelihoodType())));
-                contentTable.addCell(TableUtil.createContentCell(ViralPresence.integrations(virus)).setTextAlignment(TextAlignment.CENTER));
-                contentTable.addCell(TableUtil.createContentCell(ViralPresence.percentageCovered(virus))
+                contentTable.addCell(tableUtil.createContentCell(ViralPresence.interpretVirusName(virus.name(), virus.interpretation(), virus.virusDriverLikelihoodType())));
+                contentTable.addCell(tableUtil.createContentCell(ViralPresence.integrations(virus)).setTextAlignment(TextAlignment.CENTER));
+                contentTable.addCell(tableUtil.createContentCell(ViralPresence.percentageCovered(virus))
                         .setTextAlignment(TextAlignment.CENTER));
-                contentTable.addCell(TableUtil.createContentCell(ViralPresence.driverLikelihood(virus))
+                contentTable.addCell(tableUtil.createContentCell(ViralPresence.driverLikelihood(virus))
                         .setTextAlignment(TextAlignment.CENTER));
             }
 
-            return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+            return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
         }
     }
 
     @NotNull
-    private static Table createPharmacogeneticsGenotypesTable(@NotNull Map<String, List<PeachGenotype>> pharmacogeneticsMap) {
+    private Table createPharmacogeneticsGenotypesTable(@NotNull Map<String, List<PeachGenotype>> pharmacogeneticsMap) {
         String title = "Pharmacogenetics";
 
         if (pharmacogeneticsMap.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         } else {
             Table contentTable = TableUtil.createReportContentTable(new float[]{60, 60, 60, 100, 60},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Genotype"),
-                            TableUtil.createHeaderCell("Function"), TableUtil.createHeaderCell("Linked drugs"),
-                            TableUtil.createHeaderCell("Source")},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Genotype"),
+                            tableUtil.createHeaderCell("Function"), tableUtil.createHeaderCell("Linked drugs"),
+                            tableUtil.createHeaderCell("Source")},
                     ReportResources.CONTENT_WIDTH_WIDE);
 
             Set<String> sortedPharmacogenetics = Sets.newTreeSet(pharmacogeneticsMap.keySet());
             for (String sortPharmacogenetics : sortedPharmacogenetics) {
                 List<PeachGenotype> pharmacogeneticsGenotypeList = pharmacogeneticsMap.get(sortPharmacogenetics);
-                contentTable.addCell(TableUtil.createContentCell(sortPharmacogenetics.equals("UGT1A1") ? sortPharmacogenetics + "#" : sortPharmacogenetics));
+                contentTable.addCell(tableUtil.createContentCell(sortPharmacogenetics.equals("UGT1A1") ? sortPharmacogenetics + "#" : sortPharmacogenetics));
 
                 Table tableGenotype = new Table(new float[]{1});
                 Table tableFunction = new Table(new float[]{1});
@@ -490,25 +490,25 @@ public class GenomicAlterationsChapter implements ReportChapter {
                 Table tableSource = new Table(new float[]{1});
 
                 for (PeachGenotype pharmacogeneticsGenotype : pharmacogeneticsGenotypeList) {
-                    tableGenotype.addCell(TableUtil.createTransparentCell(pharmacogeneticsGenotype.haplotype()));
-                    tableFunction.addCell(TableUtil.createTransparentCell(pharmacogeneticsGenotype.function()));
-                    tableLinkedDrugs.addCell(TableUtil.createTransparentCell(pharmacogeneticsGenotype.linkedDrugs()));
-                    tableSource.addCell(TableUtil.createTransparentCell(new Paragraph(Pharmacogenetics.sourceName(
-                                    pharmacogeneticsGenotype.urlPrescriptionInfo())).addStyle(ReportResources.dataHighlightLinksStyle()))
+                    tableGenotype.addCell(tableUtil.createTransparentCell(pharmacogeneticsGenotype.haplotype()));
+                    tableFunction.addCell(tableUtil.createTransparentCell(pharmacogeneticsGenotype.function()));
+                    tableLinkedDrugs.addCell(tableUtil.createTransparentCell(pharmacogeneticsGenotype.linkedDrugs()));
+                    tableSource.addCell(tableUtil.createTransparentCell(new Paragraph(Pharmacogenetics.sourceName(
+                                    pharmacogeneticsGenotype.urlPrescriptionInfo())).addStyle(reportResources.dataHighlightLinksStyle()))
                             .setAction(PdfAction.createURI(Pharmacogenetics.url(pharmacogeneticsGenotype.urlPrescriptionInfo()))));
                 }
 
-                contentTable.addCell(TableUtil.createContentCell(tableGenotype));
-                contentTable.addCell(TableUtil.createContentCell(tableFunction));
-                contentTable.addCell(TableUtil.createContentCell(tableLinkedDrugs));
-                contentTable.addCell(TableUtil.createContentCell(tableSource));
+                contentTable.addCell(tableUtil.createContentCell(tableGenotype));
+                contentTable.addCell(tableUtil.createContentCell(tableFunction));
+                contentTable.addCell(tableUtil.createContentCell(tableLinkedDrugs));
+                contentTable.addCell(tableUtil.createContentCell(tableSource));
             }
             contentTable.addCell(TableUtil.createLayoutCell(1, contentTable.getNumberOfColumns())
                     .add(new Paragraph("\n #Note that we do not separately call the *36 allele. Dutch clinical " +
-                            "guidelines consider the *36 allele to be clinically equivalent to the *1 allele.").addStyle(ReportResources.subTextStyle()
+                            "guidelines consider the *36 allele to be clinically equivalent to the *1 allele.").addStyle(reportResources.subTextStyle()
                             .setTextAlignment(TextAlignment.CENTER))));
 
-            return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+            return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
         }
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/SummaryChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/SummaryChapter.java
@@ -50,9 +50,17 @@ public class SummaryChapter implements ReportChapter {
 
     @NotNull
     private final AnalysedPatientReport patientReport;
+    @NotNull
+    private final ReportResources reportResources;
+    private final TableUtil tableUtil;
+    private final TumorLocationAndTypeTable tumorLocationAndTypeTable;
 
-    public SummaryChapter(@NotNull final AnalysedPatientReport patientReport) {
+    public SummaryChapter(@NotNull final AnalysedPatientReport patientReport,
+                          @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
+        this.reportResources = reportResources;
+        this.tableUtil = new TableUtil(reportResources);
+        this.tumorLocationAndTypeTable = new TumorLocationAndTypeTable(reportResources);
     }
 
     @NotNull
@@ -96,9 +104,9 @@ public class SummaryChapter implements ReportChapter {
     @Override
     public void render(@NotNull Document reportDocument) {
 
-        reportDocument.add(TumorLocationAndTypeTable.createTumorLocation(patientReport.lamaPatientData().getPrimaryTumorType(), contentWidth()));
+        reportDocument.add(tumorLocationAndTypeTable.createTumorLocation(patientReport.lamaPatientData().getPrimaryTumorType(), contentWidth()));
         reportDocument.add(new Paragraph("\nThe information regarding 'primary tumor location', 'primary tumor type' and 'biopsy location'"
-                + "  \nis based on information received from the originating hospital.").addStyle(ReportResources.subTextStyle()));
+                + "  \nis based on information received from the originating hospital.").addStyle(reportResources.subTextStyle()));
 
         renderClinicalConclusionText(reportDocument);
         renderSpecialRemarkText(reportDocument);
@@ -119,7 +127,7 @@ public class SummaryChapter implements ReportChapter {
     @NotNull
     private Div createTumorColumn() {
         Div div = new Div();
-        div.add(new Paragraph("").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("").addStyle(reportResources.smallBodyHeadingStyle()));
         renderTumorCharacteristics(div);
         renderGenomicAlterations(div);
 
@@ -129,7 +137,7 @@ public class SummaryChapter implements ReportChapter {
     @NotNull
     private Div createGermlineColumn() {
         Div div = new Div();
-        div.add(new Paragraph("").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("").addStyle(reportResources.smallBodyHeadingStyle()));
         renderPharmacogenetics(div);
         renderHla(div);
         renderGermlineText(div);
@@ -152,7 +160,7 @@ public class SummaryChapter implements ReportChapter {
                 double impliedPurityPercentage =
                         MathUtil.mapPercentage(analysis().impliedPurity(), TumorPurity.RANGE_MIN, TumorPurity.RANGE_MAX);
                 clinicalConclusion = "Due to the lower sensitivity (" + Formats.formatPercentage(impliedPurityPercentage) + ") "
-                        + "of this test potential (subclonal) DNA aberrations might not have been detected using this test. " + ""
+                        + "of this test potential (subclonal) DNA aberrations might not have been detected using this test. "
                         + "This result should therefore be considered with caution.\n" + sentence;
             }
         } else {
@@ -161,11 +169,11 @@ public class SummaryChapter implements ReportChapter {
 
         if (!clinicalConclusion.isEmpty()) {
             Div div = createSectionStartDiv(contentWidth());
-            div.add(new Paragraph("Summary of most relevant findings").addStyle(ReportResources.sectionTitleStyle()));
+            div.add(new Paragraph("Summary of most relevant findings").addStyle(reportResources.sectionTitleStyle()));
 
-            div.add(new Paragraph(text).setWidth(contentWidth()).addStyle(ReportResources.bodyTextStyle()).setFixedLeading(11));
+            div.add(new Paragraph(text).setWidth(contentWidth()).addStyle(reportResources.bodyTextStyle()).setFixedLeading(11));
             div.add(new Paragraph("\nFurther interpretation of these results within the patient’s clinical context is required "
-                    + "by a clinician with support of a molecular tumor board.").addStyle(ReportResources.subTextStyle()));
+                    + "by a clinician with support of a molecular tumor board.").addStyle(reportResources.subTextStyle()));
 
             reportDocument.add(div);
         }
@@ -176,9 +184,9 @@ public class SummaryChapter implements ReportChapter {
 
         if (!text.isEmpty()) {
             Div div = createSectionStartDiv(contentWidth());
-            div.add(new Paragraph("Special Remark").addStyle(ReportResources.sectionTitleStyle()));
+            div.add(new Paragraph("Special Remark").addStyle(reportResources.sectionTitleStyle()));
 
-            div.add(new Paragraph(text).setWidth(contentWidth()).addStyle(ReportResources.bodyTextStyle()).setFixedLeading(11));
+            div.add(new Paragraph(text).setWidth(contentWidth()).addStyle(reportResources.bodyTextStyle()).setFixedLeading(11));
 
             reportDocument.add(div);
         }
@@ -193,7 +201,7 @@ public class SummaryChapter implements ReportChapter {
         table.setWidth(ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_LEFT);
         table.addCell(TableUtil.createLayoutCell()
                 .add(new Paragraph("Tumor characteristics").setVerticalAlignment(VerticalAlignment.TOP)
-                        .addStyle(ReportResources.sectionTitleStyle())));
+                        .addStyle(reportResources.sectionTitleStyle())));
         table.addCell(TableUtil.createLayoutCell(1, 3).setHeight(TABLE_SPACER_HEIGHT));
 
         double impliedPurity = analysis().impliedPurity();
@@ -219,24 +227,24 @@ public class SummaryChapter implements ReportChapter {
         }
 
         Style dataStyleMolecularTissuePrediction =
-                hasReliablePurity ? ReportResources.dataHighlightStyle() : ReportResources.dataHighlightNaStyle();
+                hasReliablePurity ? reportResources.dataHighlightStyle() : reportResources.dataHighlightNaStyle();
 
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Molecular tissue of origin prediction").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Molecular tissue of origin prediction").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph(cuppaPrediction).addStyle(dataStyleMolecularTissuePrediction)));
 
-        Style dataStyle = hasReliablePurity ? ReportResources.dataHighlightStyle() : ReportResources.dataHighlightNaStyle();
+        Style dataStyle = hasReliablePurity ? reportResources.dataHighlightStyle() : reportResources.dataHighlightNaStyle();
 
         String mutationalLoadString = hasReliablePurity ? analysis().tumorMutationalLoadStatus().name() + " (" + SINGLE_DECIMAL_FORMAT.format(
                 analysis().tumorMutationalLoad()) + ")" : Formats.NA_STRING;
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Tumor mutational load").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Tumor mutational load").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph(mutationalLoadString).addStyle(dataStyle)));
 
         String microSatelliteStabilityString = hasReliablePurity ? analysis().microsatelliteStatus().name() + " (" + DOUBLE_DECIMAL_FORMAT.format(
                 analysis().microsatelliteIndelsPerMb()) + ")" : Formats.NA_STRING;
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Microsatellite (in)stability").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Microsatellite (in)stability").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph(microSatelliteStabilityString).addStyle(dataStyle)));
 
         String hrdString;
@@ -245,18 +253,18 @@ public class SummaryChapter implements ReportChapter {
         if (hasReliablePurity && (ChordStatus.HR_DEFICIENT == analysis().hrdStatus()
                 || ChordStatus.HR_PROFICIENT == analysis().hrdStatus())) {
             hrdString = analysis().hrdStatus().name() + " (" + DOUBLE_DECIMAL_FORMAT.format(analysis().hrdValue()) + ")";
-            hrdStyle = ReportResources.dataHighlightStyle();
+            hrdStyle = reportResources.dataHighlightStyle();
         } else {
             hrdString = Formats.NA_STRING;
-            hrdStyle = ReportResources.dataHighlightNaStyle();
+            hrdStyle = reportResources.dataHighlightNaStyle();
         }
 
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Homologous recombination").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Homologous recombination").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph(hrdString).addStyle(hrdStyle)));
 
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Virus").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Virus").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createVirusInterpretationString(ViralPresence.virusInterpretationSummary(analysis().reportableViruses())));
 
         div.add(table);
@@ -265,30 +273,30 @@ public class SummaryChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Cell createVirusInterpretationString(@NotNull Set<String> virus) {
+    private Cell createVirusInterpretationString(@NotNull Set<String> virus) {
         String virusSummary;
         Style style;
         if (virus.size() == 0) {
             virusSummary = Formats.NONE_STRING;
-            style = ReportResources.dataHighlightNaStyle();
+            style = reportResources.dataHighlightNaStyle();
         } else {
             virusSummary = String.join(", ", virus);
-            style = ReportResources.dataHighlightStyle();
+            style = reportResources.dataHighlightStyle();
         }
 
         return createMiddleAlignedCell(2).add(createHighlightParagraph(virusSummary)).addStyle(style);
     }
 
-    private static void renderTumorPurity(boolean hasReliablePurity, @NotNull String valueLabel, double value, double min, double max,
+    private void renderTumorPurity(boolean hasReliablePurity, @NotNull String valueLabel, double value, double min, double max,
                                           @NotNull Table table) {
         String label = "Tumor purity";
-        table.addCell(createMiddleAlignedCell().add(new Paragraph(label).addStyle(ReportResources.bodyTextStyle())));
+        table.addCell(createMiddleAlignedCell().add(new Paragraph(label).addStyle(reportResources.bodyTextStyle())));
 
         if (hasReliablePurity) {
-            table.addCell(createMiddleAlignedCell().add(createHighlightParagraph(valueLabel).addStyle(ReportResources.dataHighlightStyle())));
+            table.addCell(createMiddleAlignedCell().add(createHighlightParagraph(valueLabel).addStyle(reportResources.dataHighlightStyle())));
             table.addCell(createMiddleAlignedCell().add(createInlineBarChart(value, min, max)));
         } else {
-            table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph("N/A").addStyle(ReportResources.dataHighlightNaStyle())));
+            table.addCell(createMiddleAlignedCell(2).add(createHighlightParagraph("N/A").addStyle(reportResources.dataHighlightNaStyle())));
         }
     }
 
@@ -298,34 +306,34 @@ public class SummaryChapter implements ReportChapter {
         Table table = new Table(UnitValue.createPercentArray(new float[]{1, 1}));
         table.setWidth(ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_LEFT);
         table.addCell(TableUtil.createLayoutCellSummary()
-                .add(new Paragraph("Genomic alterations in cancer genes").addStyle(ReportResources.sectionTitleStyle())));
+                .add(new Paragraph("Genomic alterations in cancer genes").addStyle(reportResources.sectionTitleStyle())));
         table.addCell(TableUtil.createLayoutCell(1, 2).setHeight(TABLE_SPACER_HEIGHT));
 
         Set<String> driverVariantGenes = SomaticVariants.driverGenesWithVariant(analysis().reportableVariants());
 
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Genes with driver mutation").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Genes with driver mutation").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createGeneSetCell(driverVariantGenes));
 
 
         Set<String> amplifiedGenes = GainsAndLosses.amplifiedGenes(analysis().gainsAndLosses());
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Amplified gene(s)").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Amplified gene(s)").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createGeneSetCell(amplifiedGenes));
 
         Set<String> copyLossGenes = GainsAndLosses.lostGenes(analysis().gainsAndLosses());
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Deleted gene(s)").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Deleted gene(s)").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createGeneSetCell(copyLossGenes));
 
         Set<String> disruptedGenes = HomozygousDisruptions.disruptedGenes(analysis().homozygousDisruptions());
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Homozygously disrupted genes").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Homozygously disrupted genes").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createGeneSetCell(disruptedGenes));
 
         Set<String> fusionGenes = GeneFusions.uniqueGeneFusions(analysis().geneFusions());
         table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                .add(new Paragraph("Gene fusions").addStyle(ReportResources.bodyTextStyle())));
+                .add(new Paragraph("Gene fusions").addStyle(reportResources.bodyTextStyle())));
         table.addCell(createGeneSetCell(fusionGenes));
 
         PurpleMicrosatelliteStatus microSatelliteStabilityString =
@@ -335,7 +343,7 @@ public class SummaryChapter implements ReportChapter {
                     analysis().gainsAndLosses(),
                     analysis().homozygousDisruptions());
             table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                    .add(new Paragraph("Potential MMR genes").addStyle(ReportResources.bodyTextStyle())));
+                    .add(new Paragraph("Potential MMR genes").addStyle(reportResources.bodyTextStyle())));
             table.addCell(createGeneSetCell(genesDisplay));
         }
 
@@ -345,7 +353,7 @@ public class SummaryChapter implements ReportChapter {
                     analysis().gainsAndLosses(),
                     analysis().homozygousDisruptions());
             table.addCell(createMiddleAlignedCell().setVerticalAlignment(VerticalAlignment.TOP)
-                    .add(new Paragraph("Potential HRD genes").addStyle(ReportResources.bodyTextStyle())));
+                    .add(new Paragraph("Potential HRD genes").addStyle(reportResources.bodyTextStyle())));
             table.addCell(createGeneSetCell(genesDisplay));
         }
 
@@ -358,14 +366,14 @@ public class SummaryChapter implements ReportChapter {
         String title = "Pharmacogenetics";
 
         if (patientReport.pharmacogeneticsGenotypes().isEmpty()) {
-            div.add(TableUtil.createNoneReportTable(title,
+            div.add(tableUtil.createNoneReportTable(title,
                     null,
                     TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY,
                     ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT));
         } else {
             Table contentTable = TableUtil.createReportContentTable(new float[]{5, 10},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"),
-                            TableUtil.createHeaderCell("Function")},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"),
+                            tableUtil.createHeaderCell("Function")},
                     ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT);
 
             Set<String> sortedPharmacogenetics = Sets.newTreeSet(patientReport.pharmacogeneticsGenotypes().keySet());
@@ -378,10 +386,10 @@ public class SummaryChapter implements ReportChapter {
                     function.add(pharmacogeneticsGenotype.function());
                 }
 
-                contentTable.addCell(TableUtil.createContentCell(sortPharmacogenetics));
-                contentTable.addCell(TableUtil.createContentCell(concat(function)));
+                contentTable.addCell(tableUtil.createContentCell(sortPharmacogenetics));
+                contentTable.addCell(tableUtil.createContentCell(concat(function)));
             }
-            div.add(TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY));
+            div.add(tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY));
         }
         divGermline.add(div);
     }
@@ -391,18 +399,18 @@ public class SummaryChapter implements ReportChapter {
         String title = "HLA Alleles";
         if (!patientReport.hlaAllelesReportingData().hlaQC().equals("PASS")) {
             String noConsent = "The QC of the HLA types do not meet the QC cut-offs";
-            div.add(TableUtil.createNoConsentReportTable(title,
+            div.add(tableUtil.createNoConsentReportTable(title,
                     noConsent,
                     TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY,
                     ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT));
         } else if (patientReport.hlaAllelesReportingData().hlaAllelesReporting().isEmpty()) {
-            div.add(TableUtil.createNoneReportTable(title,
+            div.add(tableUtil.createNoneReportTable(title,
                     null,
                     TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY,
                     ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT));
         } else {
             Table table = TableUtil.createReportContentTable(new float[]{8, 10},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Germline allele")},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Germline allele")},
                     ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT);
 
             Set<String> sortedAlleles = Sets.newTreeSet(patientReport.hlaAllelesReportingData().hlaAllelesReporting().keySet());
@@ -414,11 +422,11 @@ public class SummaryChapter implements ReportChapter {
                 for (HlaReporting hlaReporting : HLAAllele.sort(allele)) {
                     germlineAllele.add(hlaReporting.hlaAllele().germlineAllele());
                 }
-                table.addCell(TableUtil.createContentCell(sortAllele));
-                table.addCell(TableUtil.createContentCell(concat(germlineAllele)));
+                table.addCell(tableUtil.createContentCell(sortAllele));
+                table.addCell(tableUtil.createContentCell(concat(germlineAllele)));
             }
 
-            div.add(TableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY));
+            div.add(tableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN_SUMMARY));
         }
         divHla.add(div);
     }
@@ -428,9 +436,9 @@ public class SummaryChapter implements ReportChapter {
                 + "given informed consent.";
 
         Div div = createSectionStartDiv(ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT);
-        div.add(new Paragraph("Germline results").addStyle(ReportResources.sectionTitleStyle()));
+        div.add(new Paragraph("Germline results").addStyle(reportResources.sectionTitleStyle()));
 
-        div.add(new Paragraph(text).setWidth(ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT).addStyle(ReportResources.bodyTextStyle()).setFixedLeading(11));
+        div.add(new Paragraph(text).setWidth(ReportResources.CONTENT_WIDTH_WIDE_SUMMARY_RIGHT).addStyle(reportResources.bodyTextStyle()).setFixedLeading(11));
 
         divGermline.add(div);
 
@@ -455,20 +463,20 @@ public class SummaryChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Cell createMiddleAlignedCell() {
+    private Cell createMiddleAlignedCell() {
         return createMiddleAlignedCell(1);
     }
 
     @NotNull
-    private static Cell createMiddleAlignedCell(int colSpan) {
+    private Cell createMiddleAlignedCell(int colSpan) {
         return TableUtil.createLayoutCell(1, colSpan).setVerticalAlignment(VerticalAlignment.MIDDLE);
     }
 
     @NotNull
-    private static Cell createGeneSetCell(@NotNull Set<String> genes) {
+    private Cell createGeneSetCell(@NotNull Set<String> genes) {
         String geneString = (genes.size() > 0) ? String.join(", ", genes) : Formats.NONE_STRING;
 
-        Style style = (genes.size() > 0) ? ReportResources.dataHighlightStyle() : ReportResources.dataHighlightNaStyle();
+        Style style = (genes.size() > 0) ? reportResources.dataHighlightStyle() : reportResources.dataHighlightNaStyle();
 
         return createMiddleAlignedCell().add(createHighlightParagraph(geneString)).addStyle(style);
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/TumorCharacteristicsChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/TumorCharacteristicsChapter.java
@@ -44,9 +44,13 @@ public class TumorCharacteristicsChapter implements ReportChapter {
 
     @NotNull
     private final AnalysedPatientReport patientReport;
+    @NotNull
+    private final ReportResources reportResources;
 
-    public TumorCharacteristicsChapter(@NotNull final AnalysedPatientReport patientReport) {
+    public TumorCharacteristicsChapter(@NotNull final AnalysedPatientReport patientReport,
+                                       @NotNull final ReportResources reportResources) {
         this.patientReport = patientReport;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -90,7 +94,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
         }
 
         // We subtract 0.0001 from the minimum to allow visualization of a HR-score of exactly 0.
-        BarChart hrChart = new BarChart(hrdValue, HrDeficiency.RANGE_MIN - 0.0001, HrDeficiency.RANGE_MAX, "Low", "High", false);
+        BarChart hrChart = new BarChart(hrdValue, HrDeficiency.RANGE_MIN - 0.0001, HrDeficiency.RANGE_MAX, "Low", "High", false, reportResources);
         hrChart.enabled(hasReliablePurity && isHrdReliable);
         hrChart.setTickMarks(HrDeficiency.RANGE_MIN, HrDeficiency.RANGE_MAX, 0.1, SINGLE_DECIMAL_FORMAT);
 
@@ -115,7 +119,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
                         genomicAnalysis.microsatelliteIndelsPerMb()) : Formats.NA_STRING;
 
         BarChart satelliteChart =
-                new BarChart(microSatelliteStability, MicrosatelliteStatus.RANGE_MIN, MicrosatelliteStatus.RANGE_MAX, "MSS", "MSI", false);
+                new BarChart(microSatelliteStability, MicrosatelliteStatus.RANGE_MIN, MicrosatelliteStatus.RANGE_MAX, "MSS", "MSI", false, reportResources);
         satelliteChart.enabled(hasReliablePurity);
         satelliteChart.scale(InlineBarChart.LOG10_SCALE);
         satelliteChart.setTickMarks(new double[]{MicrosatelliteStatus.RANGE_MIN, 10, MicrosatelliteStatus.RANGE_MAX},
@@ -144,7 +148,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
 
         String mutationalLoadString = hasReliablePurity ? tmlStatus + " " + NO_DECIMAL_FORMAT.format(mutationalLoad) : Formats.NA_STRING;
         BarChart mutationalLoadChart =
-                new BarChart(mutationalLoad, MutationalLoad.RANGE_MIN, MutationalLoad.RANGE_MAX, "Low", "High", false);
+                new BarChart(mutationalLoad, MutationalLoad.RANGE_MIN, MutationalLoad.RANGE_MAX, "Low", "High", false, reportResources);
         mutationalLoadChart.enabled(hasReliablePurity);
         mutationalLoadChart.scale(InlineBarChart.LOG10_SCALE);
         mutationalLoadChart.setTickMarks(new double[]{MutationalLoad.RANGE_MIN, 10, 100, MutationalLoad.RANGE_MAX}, NO_DECIMAL_FORMAT);
@@ -170,7 +174,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
         String mutationalBurdenString =
                 hasReliablePurity ? SINGLE_DECIMAL_FORMAT.format(mutationalBurden) + " variants per Mb" : Formats.NA_STRING;
         BarChart mutationalBurdenChart =
-                new BarChart(mutationalBurden, MutationalBurden.RANGE_MIN, MutationalBurden.RANGE_MAX, "Low", "High", false);
+                new BarChart(mutationalBurden, MutationalBurden.RANGE_MIN, MutationalBurden.RANGE_MAX, "Low", "High", false, reportResources);
         mutationalBurdenChart.enabled(hasReliablePurity);
         mutationalBurdenChart.scale(InlineBarChart.LOG10_SCALE);
         mutationalBurdenChart.setTickMarks(new double[]{MutationalBurden.RANGE_MIN, 10, MutationalBurden.RANGE_MAX},
@@ -266,17 +270,17 @@ public class TumorCharacteristicsChapter implements ReportChapter {
         } else {
             reportDocument.add(new Paragraph(
                     "The molecular tissue of origin prediction is unreliable due to the unreliable tumor purity and "
-                            + "therefore the results are not available.").addStyle(ReportResources.subTextStyle()));
+                            + "therefore the results are not available.").addStyle(reportResources.subTextStyle()));
         }
 
         reportDocument.add(table);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String boldPart, @NotNull String regularPart) {
-        return new Paragraph(boldPart).addStyle(ReportResources.subTextBoldStyle())
+    private Paragraph createContentParagraph(@NotNull String boldPart, @NotNull String regularPart) {
+        return new Paragraph(boldPart).addStyle(reportResources.subTextBoldStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(regularPart).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(regularPart).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
@@ -284,7 +288,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
     private Div createCharacteristicDiv(@NotNull String title) {
         Div div = new Div();
         div.setKeepTogether(true);
-        div.add(new Paragraph(title).addStyle(ReportResources.sectionTitleStyle()));
+        div.add(new Paragraph(title).addStyle(reportResources.sectionTitleStyle()));
 
         return div;
     }
@@ -294,7 +298,7 @@ public class TumorCharacteristicsChapter implements ReportChapter {
         Div div = new Div();
         div.setKeepTogether(true);
 
-        div.add(new Paragraph(title).addStyle(ReportResources.smallBodyHeadingDisclaimerStyle()));
+        div.add(new Paragraph(title).addStyle(reportResources.smallBodyHeadingDisclaimerStyle()));
         return div;
     }
 
@@ -304,23 +308,23 @@ public class TumorCharacteristicsChapter implements ReportChapter {
         Div div = new Div();
         div.setKeepTogether(true);
 
-        div.add(new Paragraph(title).addStyle(ReportResources.sectionTitleStyle()));
+        div.add(new Paragraph(title).addStyle(reportResources.sectionTitleStyle()));
 
         Table table = new Table(UnitValue.createPercentArray(new float[]{10, 1, 19}));
         table.setWidth(contentWidth());
-        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(highlight)));
+        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(reportResources, highlight)));
 
         table.addCell(TableUtil.createLayoutCell(2, 1));
 
         table.addCell(TableUtil.createLayoutCell(2, 1).add(chart));
         table.addCell(TableUtil.createLayoutCell()
-                .add(new Paragraph(description).addStyle(ReportResources.bodyTextStyle())
+                .add(new Paragraph(description).addStyle(reportResources.bodyTextStyle())
                         .setFixedLeading(ReportResources.BODY_TEXT_LEADING)));
         table.addCell(TableUtil.createLayoutCell(1, 3).setHeight(TABLE_SPACER_HEIGHT));
         div.add(table);
 
         if (displayFootnote) {
-            div.add(new Paragraph(footnote).addStyle(ReportResources.subTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
+            div.add(new Paragraph(footnote).addStyle(reportResources.subTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
         }
 
         return div;

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailChapter.java
@@ -20,9 +20,14 @@ public class QCFailChapter implements ReportChapter {
 
     @NotNull
     private final QCFailReport failReport;
+    @NotNull
+    private final ReportResources reportResources;
+    private final TumorLocationAndTypeTable tumorLocationAndTypeTable;
 
-    public QCFailChapter(@NotNull QCFailReport failReport) {
+    public QCFailChapter(@NotNull QCFailReport failReport, @NotNull ReportResources reportResources) {
         this.failReport = failReport;
+        this.reportResources = reportResources;
+        this.tumorLocationAndTypeTable = new TumorLocationAndTypeTable(reportResources);
     }
 
     @NotNull
@@ -49,10 +54,10 @@ public class QCFailChapter implements ReportChapter {
 
     @Override
     public void render(@NotNull Document reportDocument) {
-        reportDocument.add(TumorLocationAndTypeTable.createTumorLocation(failReport.lamaPatientData().getPrimaryTumorType(), contentWidth()));
+        reportDocument.add(tumorLocationAndTypeTable.createTumorLocation(failReport.lamaPatientData().getPrimaryTumorType(), contentWidth()));
 
         reportDocument.add(new Paragraph("The information regarding 'primary tumor location', 'primary tumor type' and 'biopsy location'"
-                + " is based on information received from the originating hospital.").addStyle(ReportResources.subTextSmallStyle()));
+                + " is based on information received from the originating hospital.").addStyle(reportResources.subTextSmallStyle()));
         reportDocument.add(LineDivider.createLineDivider(contentWidth()));
 
         reportDocument.add(createFailReasonDiv(failReport.reason()));
@@ -61,7 +66,7 @@ public class QCFailChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createFailReasonDiv(@NotNull QCFailReason failReason) {
+    private Div createFailReasonDiv(@NotNull QCFailReason failReason) {
         String reason = Formats.NA_STRING;
         String explanation = Formats.NA_STRING;
         String explanationDetail = Formats.NA_STRING;
@@ -106,9 +111,9 @@ public class QCFailChapter implements ReportChapter {
         Div div = new Div();
         div.setKeepTogether(true);
 
-        div.add(new Paragraph(reason).addStyle(ReportResources.dataHighlightStyle()));
-        div.add(new Paragraph(explanation).addStyle(ReportResources.bodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
-        div.add(new Paragraph(explanationDetail).addStyle(ReportResources.subTextStyle())
+        div.add(new Paragraph(reason).addStyle(reportResources.dataHighlightStyle()));
+        div.add(new Paragraph(explanation).addStyle(reportResources.bodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
+        div.add(new Paragraph(explanationDetail).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING));
         return div;
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailDisclaimerChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailDisclaimerChapter.java
@@ -22,9 +22,11 @@ import org.jetbrains.annotations.NotNull;
 public class QCFailDisclaimerChapter implements ReportChapter {
     @NotNull
     private final QCFailReport failReport;
+    private final ReportResources reportResources;
 
-    public QCFailDisclaimerChapter(@NotNull QCFailReport failReport) {
+    public QCFailDisclaimerChapter(@NotNull QCFailReport failReport, @NotNull ReportResources reportResources) {
         this.failReport = failReport;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -47,8 +49,9 @@ public class QCFailDisclaimerChapter implements ReportChapter {
     @Override
     public void render(@NotNull Document reportDocument) {
         reportDocument.add(createContentBody());
-        reportDocument.add(ReportSignature.createSignatureDiv(failReport.logoRVAPath(), failReport.signaturePath()).setMarginTop(15));
-        reportDocument.add(ReportSignature.createEndOfReportIndication());
+        ReportSignature reportSignature = ReportSignature.create(reportResources);
+        reportDocument.add(reportSignature.createSignatureDiv(failReport.logoRVAPath(), failReport.signaturePath()).setMarginTop(15));
+        reportDocument.add(reportSignature.createEndOfReportIndication());
     }
 
     @NotNull
@@ -211,50 +214,50 @@ public class QCFailDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createSampleDetailsDiv() {
+    private Div createSampleDetailsDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Sample details").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Sample details").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Div createDisclaimerDiv() {
+    private Div createDisclaimerDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Disclaimer").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Disclaimer").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Paragraph createContentParagraphRed(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraphRed(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+    private Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
+    private Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
                                                          @NotNull String regularPart2, @NotNull String boldPart2) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .add(regularPart2)
-                .add(new Text(boldPart2).addStyle(ReportResources.smallBodyBoldTextStyle()))
+                .add(new Text(boldPart2).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraphTwiceWithOneBold(@NotNull String regularPart, @NotNull String boldPart,
+    private Paragraph createContentParagraphTwiceWithOneBold(@NotNull String regularPart, @NotNull String boldPart,
                                                                     @NotNull String regularPart2, @NotNull String boldPart2) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .add(regularPart2)
-                .add(new Text(boldPart2).addStyle(ReportResources.smallBodyBoldTextStyle()))
+                .add(new Text(boldPart2).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailPGXChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/failed/QCFailPGXChapter.java
@@ -31,9 +31,15 @@ public class QCFailPGXChapter implements ReportChapter {
 
     @NotNull
     private final QCFailReport failReport;
+    @NotNull
+    private final ReportResources reportResources;
+    @NotNull
+    private final TableUtil tableUtil;
 
-    public QCFailPGXChapter(@NotNull QCFailReport failReport) {
+    public QCFailPGXChapter(@NotNull QCFailReport failReport, @NotNull ReportResources reportResources) {
         this.failReport = failReport;
+        this.reportResources = reportResources;
+        this.tableUtil = new TableUtil(reportResources);
     }
 
     @NotNull
@@ -87,59 +93,59 @@ public class QCFailPGXChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Table createHlaTable(@NotNull HlaAllelesReportingData lilac) {
+    private Table createHlaTable(@NotNull HlaAllelesReportingData lilac) {
 
         String title = "HLA Alleles";
         Table table = TableUtil.createReportContentTable(new float[]{10, 10, 10},
-                new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Germline allele"),
-                        TableUtil.createHeaderCell("Germline copies")},
+                new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Germline allele"),
+                        tableUtil.createHeaderCell("Germline copies")},
                 ReportResources.CONTENT_WIDTH_WIDE_SMALL);
         if (!lilac.hlaQC().equals("PASS")) {
             String noConsent = "The QC of the HLA types do not meet the QC cut-offs";
-            return TableUtil.createNoConsentReportTable(title,
+            return tableUtil.createNoConsentReportTable(title,
                     noConsent,
                     TableUtil.TABLE_BOTTOM_MARGIN,
                     ReportResources.CONTENT_WIDTH_WIDE_SMALL);
         } else if (lilac.hlaAllelesReporting().isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE_SMALL);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE_SMALL);
         } else {
             Set<String> sortedAlleles = Sets.newTreeSet(lilac.hlaAllelesReporting().keySet().stream().collect(Collectors.toSet()));
             for (String sortAllele : sortedAlleles) {
                 List<HlaReporting> allele = lilac.hlaAllelesReporting().get(sortAllele);
-                table.addCell(TableUtil.createContentCell(sortAllele));
+                table.addCell(tableUtil.createContentCell(sortAllele));
 
                 Table tableGermlineAllele = new Table(new float[]{1});
                 Table tableGermlineCopies = new Table(new float[]{1});
 
                 for (HlaReporting hlaAlleleReporting : HLAAllele.sort(allele)) {
-                    tableGermlineAllele.addCell(TableUtil.createTransparentCell(hlaAlleleReporting.hlaAllele().germlineAllele()));
-                    tableGermlineCopies.addCell(TableUtil.createTransparentCell(String.valueOf(Math.round(hlaAlleleReporting.germlineCopies()))));
+                    tableGermlineAllele.addCell(tableUtil.createTransparentCell(hlaAlleleReporting.hlaAllele().germlineAllele()));
+                    tableGermlineCopies.addCell(tableUtil.createTransparentCell(String.valueOf(Math.round(hlaAlleleReporting.germlineCopies()))));
                 }
 
-                table.addCell(TableUtil.createContentCell(tableGermlineAllele));
-                table.addCell(TableUtil.createContentCell(tableGermlineCopies));
+                table.addCell(tableUtil.createContentCell(tableGermlineAllele));
+                table.addCell(tableUtil.createContentCell(tableGermlineCopies));
             }
         }
-        return TableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
+        return tableUtil.createWrappingReportTable(title, null, table, TableUtil.TABLE_BOTTOM_MARGIN);
     }
 
     @NotNull
-    private static Table createPharmacogeneticsGenotypesTable(@NotNull Map<String, List<PeachGenotype>> pharmacogeneticsGenotypes) {
+    private Table createPharmacogeneticsGenotypesTable(@NotNull Map<String, List<PeachGenotype>> pharmacogeneticsGenotypes) {
         String title = "Pharmacogenetics";
 
         if (pharmacogeneticsGenotypes.isEmpty()) {
-            return TableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
+            return tableUtil.createNoneReportTable(title, null, TableUtil.TABLE_BOTTOM_MARGIN, ReportResources.CONTENT_WIDTH_WIDE);
         } else {
             Table contentTable = TableUtil.createReportContentTable(new float[]{60, 60, 60, 100, 60},
-                    new Cell[]{TableUtil.createHeaderCell("Gene"), TableUtil.createHeaderCell("Genotype"),
-                            TableUtil.createHeaderCell("Function"), TableUtil.createHeaderCell("Linked drugs"),
-                            TableUtil.createHeaderCell("Source")},
+                    new Cell[]{tableUtil.createHeaderCell("Gene"), tableUtil.createHeaderCell("Genotype"),
+                            tableUtil.createHeaderCell("Function"), tableUtil.createHeaderCell("Linked drugs"),
+                            tableUtil.createHeaderCell("Source")},
                     ReportResources.CONTENT_WIDTH_WIDE);
 
             Set<String> sortedPharmacogenetics = Sets.newTreeSet(pharmacogeneticsGenotypes.keySet());
             for (String sortPharmacogenetics : sortedPharmacogenetics) {
                 List<PeachGenotype> pharmacogeneticsGenotypeList = pharmacogeneticsGenotypes.get(sortPharmacogenetics);
-                contentTable.addCell(TableUtil.createContentCell(sortPharmacogenetics));
+                contentTable.addCell(tableUtil.createContentCell(sortPharmacogenetics));
 
                 Table tableGenotype = new Table(new float[]{1});
                 Table tableFunction = new Table(new float[]{1});
@@ -147,50 +153,50 @@ public class QCFailPGXChapter implements ReportChapter {
                 Table tableSource = new Table(new float[]{1});
 
                 for (PeachGenotype peachGenotype : pharmacogeneticsGenotypeList) {
-                    tableGenotype.addCell(TableUtil.createTransparentCell(peachGenotype.haplotype()));
-                    tableFunction.addCell(TableUtil.createTransparentCell(peachGenotype.function()));
-                    tableLinkedDrugs.addCell(TableUtil.createTransparentCell(peachGenotype.linkedDrugs()));
-                    tableSource.addCell(TableUtil.createTransparentCell(new Paragraph(Pharmacogenetics.sourceName(peachGenotype.urlPrescriptionInfo())).addStyle(
-                                    ReportResources.dataHighlightLinksStyle()))
+                    tableGenotype.addCell(tableUtil.createTransparentCell(peachGenotype.haplotype()));
+                    tableFunction.addCell(tableUtil.createTransparentCell(peachGenotype.function()));
+                    tableLinkedDrugs.addCell(tableUtil.createTransparentCell(peachGenotype.linkedDrugs()));
+                    tableSource.addCell(tableUtil.createTransparentCell(new Paragraph(Pharmacogenetics.sourceName(peachGenotype.urlPrescriptionInfo())).addStyle(
+                                    reportResources.dataHighlightLinksStyle()))
                             .setAction(PdfAction.createURI(Pharmacogenetics.url(peachGenotype.urlPrescriptionInfo()))));
                 }
 
-                contentTable.addCell(TableUtil.createContentCell(tableGenotype));
-                contentTable.addCell(TableUtil.createContentCell(tableFunction));
-                contentTable.addCell(TableUtil.createContentCell(tableLinkedDrugs));
-                contentTable.addCell(TableUtil.createContentCell(tableSource));
+                contentTable.addCell(tableUtil.createContentCell(tableGenotype));
+                contentTable.addCell(tableUtil.createContentCell(tableFunction));
+                contentTable.addCell(tableUtil.createContentCell(tableLinkedDrugs));
+                contentTable.addCell(tableUtil.createContentCell(tableSource));
             }
-            return TableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
+            return tableUtil.createWrappingReportTable(title, null, contentTable, TableUtil.TABLE_BOTTOM_MARGIN);
         }
     }
 
     @NotNull
-    private static Div createContentDiv(@NotNull String[] contentParagraphs) {
+    private Div createContentDiv(@NotNull String[] contentParagraphs) {
         Div div = new Div();
         for (String s : contentParagraphs) {
-            div.add(new Paragraph(s).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
+            div.add(new Paragraph(s).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
         }
         return div;
     }
 
     @NotNull
-    private static Paragraph createSectionTitle(@NotNull String sectionTitle) {
-        return new Paragraph(sectionTitle).addStyle(ReportResources.smallBodyHeadingStyle());
+    private Paragraph createSectionTitle(@NotNull String sectionTitle) {
+        return new Paragraph(sectionTitle).addStyle(reportResources.smallBodyHeadingStyle());
     }
 
     @NotNull
-    private static Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
                                                           @NotNull String link) {
-        return new Paragraph(string1).addStyle(ReportResources.subTextStyle())
+        return new Paragraph(string1).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string2).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link)))
+                .add(new Text(string2).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string3).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(string3).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
+    private Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String string2, @NotNull String string3,
                                                      @NotNull String link) {
         Div div = new Div();
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelChapter.java
@@ -19,9 +19,14 @@ public class PanelChapter implements ReportChapter {
 
     @NotNull
     private final PanelReport report;
+    @NotNull
+    private final ReportResources reportResources;
+    private final TumorLocationAndTypeTable tumorLocationAndTypeTable;
 
-    public PanelChapter(@NotNull PanelReport report) {
+    public PanelChapter(@NotNull PanelReport report, @NotNull ReportResources reportResources) {
         this.report = report;
+        this.reportResources = reportResources;
+        this.tumorLocationAndTypeTable = new TumorLocationAndTypeTable(reportResources);
     }
 
     @NotNull
@@ -49,9 +54,9 @@ public class PanelChapter implements ReportChapter {
     @Override
     public void render(@NotNull Document reportDocument) {
 
-        reportDocument.add(TumorLocationAndTypeTable.createTumorLocation(report.lamaPatientData().getPrimaryTumorType(), contentWidth()));
+        reportDocument.add(tumorLocationAndTypeTable.createTumorLocation(report.lamaPatientData().getPrimaryTumorType(), contentWidth()));
         reportDocument.add(new Paragraph("The information regarding 'primary tumor location', 'primary tumor type' and 'biopsy location'"
-                + " is based on information received from the originating hospital.").addStyle(ReportResources.subTextSmallStyle()));
+                + " is based on information received from the originating hospital.").addStyle(reportResources.subTextSmallStyle()));
         reportDocument.add(LineDivider.createLineDivider(contentWidth()));
 
         reportDocument.add(createResultDiv());
@@ -62,20 +67,20 @@ public class PanelChapter implements ReportChapter {
         Div div = new Div();
         div.setKeepTogether(true);
 
-        div.add(new Paragraph("Data result file information").addStyle(ReportResources.dataHighlightStyle()));
+        div.add(new Paragraph("Data result file information").addStyle(reportResources.dataHighlightStyle()));
         div.add(createContentParagraph("VCF file name: ", report.VCFFilename()));
 
         return div;
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+    private Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelExplanationChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelExplanationChapter.java
@@ -17,7 +17,11 @@ import org.jetbrains.annotations.NotNull;
 
 public class PanelExplanationChapter implements ReportChapter {
 
-    public PanelExplanationChapter() {
+    @NotNull
+    private final ReportResources reportResources;
+
+    public PanelExplanationChapter(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -41,15 +45,15 @@ public class PanelExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createExplanationDiv() {
+    private Div createExplanationDiv() {
         Div div = new Div();
 
-        div.add(new Paragraph("Details on the report general ").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Details on the report general ").addStyle(reportResources.smallBodyHeadingStyle()));
         div.add(createContentParagraph("The variant calling of the sequencing data is based on reference genome version GRCh38."));
         div.add(createContentDivWithLinkThree("The gene name list can be downloaded from ", " https://storage.googleapis.com/hmf-public/OncoPanel-Resources/latest_oncopanel.zip",
                 "."));
-        div.add(new Paragraph("").addStyle(ReportResources.smallBodyHeadingStyle()));
-        div.add(new Paragraph("Details on the VCF file").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("").addStyle(reportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Details on the VCF file").addStyle(reportResources.smallBodyHeadingStyle()));
         div.add(createContentDivWithLinkThree("A short description of the headers present in the VCF file can be downloaded from ",
                 " https://storage.googleapis.com/hmf-public/OncoPanel-Resources/latest_oncopanel.zip",
                 "."));
@@ -57,12 +61,12 @@ public class PanelExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String link, @NotNull String string3) {
+    private Div createContentDivWithLinkThree(@NotNull String string1, @NotNull String link, @NotNull String string3) {
         Div div = new Div();
 
         div.add(createParaGraphWithLinkThree(string1, link, string3));
@@ -70,12 +74,12 @@ public class PanelExplanationChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String link, @NotNull String string3) {
-        return new Paragraph(string1).addStyle(ReportResources.subTextStyle())
+    private Paragraph createParaGraphWithLinkThree(@NotNull String string1, @NotNull String link, @NotNull String string3) {
+        return new Paragraph(string1).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(link).addStyle(ReportResources.urlStyle()).setAction(PdfAction.createURI(link)))
+                .add(new Text(link).addStyle(reportResources.urlStyle()).setAction(PdfAction.createURI(link)))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING)
-                .add(new Text(string3).addStyle(ReportResources.subTextStyle()))
+                .add(new Text(string3).addStyle(reportResources.subTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelQCFailChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/PanelQCFailChapter.java
@@ -24,9 +24,14 @@ public class PanelQCFailChapter implements ReportChapter {
 
     @NotNull
     private final PanelFailReport report;
+    @NotNull
+    private final ReportResources reportResources;
+    private final TumorLocationAndTypeTable tumorLocationAndTypeTable;
 
-    public PanelQCFailChapter(@NotNull PanelFailReport report) {
+    public PanelQCFailChapter(@NotNull PanelFailReport report, @NotNull ReportResources reportResources) {
         this.report = report;
+        this.reportResources = reportResources;
+        this.tumorLocationAndTypeTable = new TumorLocationAndTypeTable(reportResources);
     }
 
     @NotNull
@@ -53,16 +58,16 @@ public class PanelQCFailChapter implements ReportChapter {
 
     @Override
     public void render(@NotNull Document reportDocument) {
-        reportDocument.add(TumorLocationAndTypeTable.createTumorLocation(report.lamaPatientData().getPrimaryTumorType(), contentWidth()));
+        reportDocument.add(tumorLocationAndTypeTable.createTumorLocation(report.lamaPatientData().getPrimaryTumorType(), contentWidth()));
         reportDocument.add(new Paragraph("The information regarding 'primary tumor location', 'primary tumor type' and 'biopsy location'"
-                + " is based on information received from the originating hospital.").addStyle(ReportResources.subTextSmallStyle()));
+                + " is based on information received from the originating hospital.").addStyle(reportResources.subTextSmallStyle()));
         reportDocument.add(LineDivider.createLineDivider(contentWidth()));
         reportDocument.add(createFailReasonDiv(report.panelFailReason()));
         reportDocument.add(LineDivider.createLineDivider(contentWidth()));
     }
 
     @NotNull
-    private static Div createFailReasonDiv(@NotNull PanelFailReason failReason) {
+    private Div createFailReasonDiv(@NotNull PanelFailReason failReason) {
         String reason = Formats.NA_STRING;
         String explanation = Formats.NA_STRING;
         String explanationDetail = Formats.NA_STRING;
@@ -84,9 +89,9 @@ public class PanelQCFailChapter implements ReportChapter {
         Div div = new Div();
         div.setKeepTogether(true);
 
-        div.add(new Paragraph(reason).addStyle(ReportResources.dataHighlightStyle()));
-        div.add(new Paragraph(explanation).addStyle(ReportResources.bodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
-        div.add(new Paragraph(explanationDetail).addStyle(ReportResources.subTextStyle())
+        div.add(new Paragraph(reason).addStyle(reportResources.dataHighlightStyle()));
+        div.add(new Paragraph(explanation).addStyle(reportResources.bodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING));
+        div.add(new Paragraph(explanationDetail).addStyle(reportResources.subTextStyle())
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING));
         return div;
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/SampleAndDisclaimerChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/SampleAndDisclaimerChapter.java
@@ -22,9 +22,12 @@ public class SampleAndDisclaimerChapter implements ReportChapter {
 
     @NotNull
     private final PanelReport report;
+    @NotNull
+    private final ReportResources reportResources;
 
-    public SampleAndDisclaimerChapter(@NotNull PanelReport report) {
+    public SampleAndDisclaimerChapter(@NotNull PanelReport report, @NotNull ReportResources reportResources) {
         this.report = report;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -52,9 +55,9 @@ public class SampleAndDisclaimerChapter implements ReportChapter {
         table.addCell(TableUtil.createLayoutCell());
         table.addCell(TableUtil.createLayoutCell().add(createDisclaimerColumn()));
         reportDocument.add(table);
-
-        reportDocument.add(ReportSignature.createSignatureDivPanel(report.signaturePath()));
-        reportDocument.add(ReportSignature.createEndOfReportIndication());
+        ReportSignature reportSignature = ReportSignature.create(reportResources);
+        reportDocument.add(reportSignature.createSignatureDivPanel(report.signaturePath()));
+        reportDocument.add(reportSignature.createEndOfReportIndication());
     }
 
     @NotNull
@@ -88,12 +91,12 @@ public class SampleAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createContentParagraphRed(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraphRed(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph generateHMFSampleIDParagraph(@NotNull String reportingId, boolean isStudy) {
+    private Paragraph generateHMFSampleIDParagraph(@NotNull String reportingId, boolean isStudy) {
         if (isStudy) {
             return createContentParagraph("Study id: ", reportingId);
         } else {
@@ -126,36 +129,36 @@ public class SampleAndDisclaimerChapter implements ReportChapter {
     }
 
     @NotNull
-    private static Div createDisclaimerDiv() {
+    private Div createDisclaimerDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Disclaimer").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Disclaimer").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Div createSampleDetailsDiv() {
+    private Div createSampleDetailsDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Sample details").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Sample details").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+    private Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
+    private Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
             @NotNull String regularPart2, @NotNull String boldPart2) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .add(regularPart2)
-                .add(new Text(boldPart2).addStyle(ReportResources.smallBodyBoldTextStyle()))
+                .add(new Text(boldPart2).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/SampleAndDisclaimerChapterFail.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/panel/SampleAndDisclaimerChapterFail.java
@@ -22,9 +22,12 @@ public class SampleAndDisclaimerChapterFail implements ReportChapter {
 
     @NotNull
     private final PanelFailReport report;
+    @NotNull
+    private final ReportResources reportResources;
 
-    public SampleAndDisclaimerChapterFail(@NotNull PanelFailReport report) {
+    public SampleAndDisclaimerChapterFail(@NotNull PanelFailReport report, @NotNull ReportResources reportResources) {
         this.report = report;
+        this.reportResources = reportResources;
     }
 
     @NotNull
@@ -52,9 +55,9 @@ public class SampleAndDisclaimerChapterFail implements ReportChapter {
         table.addCell(TableUtil.createLayoutCell());
         table.addCell(TableUtil.createLayoutCell().add(createDisclaimerColumn()));
         reportDocument.add(table);
-
-        reportDocument.add(ReportSignature.createSignatureDivPanel(report.signaturePath()));
-        reportDocument.add(ReportSignature.createEndOfReportIndication());
+        ReportSignature reportSignature = ReportSignature.create(reportResources);
+        reportDocument.add(reportSignature.createSignatureDivPanel(report.signaturePath()));
+        reportDocument.add(reportSignature.createEndOfReportIndication());
     }
 
     @NotNull
@@ -88,12 +91,12 @@ public class SampleAndDisclaimerChapterFail implements ReportChapter {
     }
 
     @NotNull
-    private static Paragraph createContentParagraphRed(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraphRed(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyleRed()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph generateHMFSampleIDParagraph(@NotNull String reportingId) {
+    private Paragraph generateHMFSampleIDParagraph(@NotNull String reportingId) {
         if (reportingId.substring(0, 4).matches("[a-zA-Z]+")) {
             return createContentParagraph("Study id: ", reportingId);
         } else {
@@ -118,36 +121,36 @@ public class SampleAndDisclaimerChapterFail implements ReportChapter {
     }
 
     @NotNull
-    private static Div createDisclaimerDiv() {
+    private Div createDisclaimerDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Disclaimer").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Disclaimer").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Div createSampleDetailsDiv() {
+    private Div createSampleDetailsDiv() {
         Div div = new Div();
-        div.add(new Paragraph("Sample details").addStyle(ReportResources.smallBodyHeadingStyle()));
+        div.add(new Paragraph("Sample details").addStyle(reportResources.smallBodyHeadingStyle()));
         return div;
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+    private Paragraph createContentParagraph(@NotNull String regularPart, @NotNull String boldPart) {
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
+    private Paragraph createContentParagraphTwice(@NotNull String regularPart, @NotNull String boldPart,
                                                          @NotNull String regularPart2, @NotNull String boldPart2) {
-        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(ReportResources.smallBodyBoldTextStyle()))
+        return createContentParagraph(regularPart).add(new Text(boldPart).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .add(regularPart2)
-                .add(new Text(boldPart2).addStyle(ReportResources.smallBodyBoldTextStyle()))
+                .add(new Text(boldPart2).addStyle(reportResources.smallBodyBoldTextStyle()))
                 .setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 
     @NotNull
-    private static Paragraph createContentParagraph(@NotNull String text) {
-        return new Paragraph(text).addStyle(ReportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
+    private Paragraph createContentParagraph(@NotNull String text) {
+        return new Paragraph(text).addStyle(reportResources.smallBodyTextStyle()).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/BarChart.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/BarChart.java
@@ -29,7 +29,7 @@ public class BarChart extends InlineBarChart {
     private final String lowLabel;
     private final String highLabel;
     private final boolean forceMarkerInRoundedRectangle;
-
+    private final ReportResources reportResources;
     private boolean underShootEnabled = false;
     private String undershootLabel = "";
 
@@ -40,12 +40,13 @@ public class BarChart extends InlineBarChart {
     private Indicator threshold = null;
 
     public BarChart(double value, double min, double max, @NotNull String lowLabel, @NotNull String highLabel,
-            boolean forceMarkerInRoundedRectangle) {
+            boolean forceMarkerInRoundedRectangle, @NotNull ReportResources reportResources) {
         super(value, min, max);
         super.setHeight(HEIGHT);
         this.lowLabel = lowLabel;
         this.highLabel = highLabel;
         this.forceMarkerInRoundedRectangle = forceMarkerInRoundedRectangle;
+        this.reportResources = reportResources;
     }
 
     private void setTickMarks(@NotNull Indicator... tickMarks) {
@@ -129,11 +130,11 @@ public class BarChart extends InlineBarChart {
             Color outlineColor = isEnabled() ? ReportResources.PALETTE_MID_BLUE : ReportResources.PALETTE_LIGHT_GREY;
             Color labelColor = isEnabled() ? ReportResources.PALETTE_BLACK : ReportResources.PALETTE_LIGHT_GREY;
 
-            cv.showTextAligned(new Paragraph(lowLabel).addStyle(ReportResources.smallBodyHeadingStyle().setFontColor(labelColor)),
+            cv.showTextAligned(new Paragraph(lowLabel).addStyle(reportResources.smallBodyHeadingStyle().setFontColor(labelColor)),
                     boundingBox.getLeft(),
                     boundingBox.getTop() - 25,
                     TextAlignment.LEFT);
-            cv.showTextAligned(new Paragraph(highLabel).addStyle(ReportResources.smallBodyHeadingStyle().setFontColor(labelColor)),
+            cv.showTextAligned(new Paragraph(highLabel).addStyle(reportResources.smallBodyHeadingStyle().setFontColor(labelColor)),
                     boundingBox.getRight(),
                     boundingBox.getTop() - 25,
                     TextAlignment.RIGHT);
@@ -151,7 +152,7 @@ public class BarChart extends InlineBarChart {
                 canvas.setFillColor(ReportResources.PALETTE_WHITE);
                 canvas.fill();
 
-                cv.showTextAligned(new Paragraph(undershootLabel).addStyle(ReportResources.subTextStyle()
+                cv.showTextAligned(new Paragraph(undershootLabel).addStyle(reportResources.subTextStyle()
                         .setFontSize(6)
                         .setFontColor(labelColor)), outerBB.getLeft() + OVER_UNDER_SHOOT_LABEL_OFFSET, tickY, TextAlignment.LEFT);
             }
@@ -171,7 +172,7 @@ public class BarChart extends InlineBarChart {
                 canvas.circle(outerBB.getLeft() + outerRadius, outerBB.getY() + outerRadius, outerRadius + OVER_UNDERSHOOT_OVERLAP);
                 canvas.fill();
 
-                cv.showTextAligned(new Paragraph(overshootLabel).addStyle(ReportResources.subTextStyle()
+                cv.showTextAligned(new Paragraph(overshootLabel).addStyle(reportResources.subTextStyle()
                         .setFontSize(6)
                         .setFontColor(labelColor)), outerBB.getRight() - OVER_UNDER_SHOOT_LABEL_OFFSET, tickY, TextAlignment.RIGHT);
             }
@@ -200,7 +201,7 @@ public class BarChart extends InlineBarChart {
 
                 TextAlignment alignment = !tickMark.equals(tickMarks[tickMarks.length - 1]) ? TextAlignment.CENTER : TextAlignment.RIGHT;
 
-                cv.showTextAligned(new Paragraph(tickMark.name).addStyle(ReportResources.subTextStyle()
+                cv.showTextAligned(new Paragraph(tickMark.name).addStyle(reportResources.subTextStyle()
                         .setFontSize(6)
                         .setFontColor(labelColor)), x, tickY, alignment);
             }
@@ -218,13 +219,13 @@ public class BarChart extends InlineBarChart {
                 canvas.setStrokeColor(ReportResources.PALETTE_PINK);
                 canvas.stroke();
 
-                cv.showTextAligned(new Paragraph("\u2192").addStyle(ReportResources.subTextBoldStyle().setFontSize(6))
+                cv.showTextAligned(new Paragraph("\u2192").addStyle(reportResources.subTextBoldStyle().setFontSize(6))
                                 .setFontColor(ReportResources.PALETTE_PINK),
                         x + 4.5f,
                         mainOuterBB.getTop() + 18f,
                         TextAlignment.LEFT,
                         VerticalAlignment.TOP);
-                cv.showTextAligned(new Paragraph(threshold.name.toUpperCase()).addStyle(ReportResources.subTextBoldStyle().setFontSize(6))
+                cv.showTextAligned(new Paragraph(threshold.name.toUpperCase()).addStyle(reportResources.subTextBoldStyle().setFontSize(6))
                                 .setFontColor(ReportResources.PALETTE_PINK),
                         x + 12.5f,
                         mainOuterBB.getTop() + 18f,

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/DataLabel.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/DataLabel.java
@@ -10,12 +10,12 @@ import org.jetbrains.annotations.NotNull;
 
 public final class DataLabel {
 
-    private DataLabel() {
+    private DataLabel(ReportResources reportResources) {
     }
 
     @NotNull
-    public static Paragraph createDataLabel(@NotNull String text) {
-        return new Paragraph().add(new Text(text).addStyle(ReportResources.dataHighlightStyle())
+    public static Paragraph createDataLabel(@NotNull ReportResources reportResources, @NotNull String text) {
+        return new Paragraph().add(new Text(text).addStyle(reportResources.dataHighlightStyle())
                 .setBackgroundColor(ReportResources.PALETTE_BLUE)
                 .setFontColor(ReportResources.PALETTE_WHITE)
                 .setBorder(new SolidBorder(ReportResources.PALETTE_BLUE, 2))

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Footer.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Footer.java
@@ -18,6 +18,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class Footer {
 
+    private final ReportResources reportResources;
+
+    public Footer(ReportResources reportResources) {
+        this.reportResources = reportResources;
+    }
+
     private final List<PageNumberTemplate> pageNumberTemplates = Lists.newArrayList();
 
     public void renderFooter(@NotNull PdfPage page, @NotNull String qsFormNumber, boolean fullWidth) {
@@ -29,7 +35,7 @@ public class Footer {
 
         PdfFormXObject pageNumberTemplate = new PdfFormXObject(new Rectangle(0, 0, 200, 20));
         canvas.addXObject(pageNumberTemplate, 58, 20);
-        pageNumberTemplates.add(new PageNumberTemplate(pageNumber, version, pageNumberTemplate));
+        pageNumberTemplates.add(new PageNumberTemplate(pageNumber, version, pageNumberTemplate, reportResources));
 
         BaseMarker.renderMarkerGrid(fullWidth ? 5 : 3, 1, 156, 87, 22, 0, .2f, 0, canvas);
 
@@ -49,18 +55,20 @@ public class Footer {
         private final String qsFormNumber;
         @NotNull
         private final PdfFormXObject template;
+        private final ReportResources reportResources;
 
-        PageNumberTemplate(int pageNumber, String qsFormNumber, @NotNull PdfFormXObject template) {
+        PageNumberTemplate(int pageNumber, String qsFormNumber, @NotNull PdfFormXObject template, @NotNull ReportResources reportResources) {
             this.pageNumber = pageNumber;
             this.qsFormNumber = qsFormNumber;
             this.template = template;
+            this.reportResources = reportResources;
         }
 
         void renderPageNumber(int totalPageCount, @NotNull PdfDocument document) {
             String displayString = pageNumber + "/" + totalPageCount + " " + qsFormNumber;
 
             Canvas canvas = new Canvas(template, document);
-            canvas.showTextAligned(new Paragraph().add(displayString).addStyle(ReportResources.pageNumberStyle()),
+            canvas.showTextAligned(new Paragraph().add(displayString).addStyle(reportResources.pageNumberStyle()),
                     0,
                     0,
                     TextAlignment.LEFT);

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Header.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Header.java
@@ -29,8 +29,10 @@ public class Header {
     @Nullable
     private final PdfImageXObject companyLogoObj;
     private final List<ChapterPageCounter> chapterPageCounters = Lists.newArrayList();
+    @NotNull
+    private final ReportResources reportResources;
 
-    public Header(@NotNull String logoCompanyPath) {
+    public Header(@NotNull String logoCompanyPath, @NotNull ReportResources reportResources) {
         ImageData companyLogoImage = null;
         try {
             companyLogoImage = ImageDataFactory.create(logoCompanyPath);
@@ -38,6 +40,7 @@ public class Header {
             LOGGER.warn("Could not load company logo image from {}", logoCompanyPath);
         }
         companyLogoObj = companyLogoImage != null ? new PdfImageXObject(companyLogoImage) : null;
+        this.reportResources = reportResources;
     }
 
     public void renderHeader(@NotNull String chapterTitle, @NotNull String pdfTitle, boolean firstPageOfChapter, @NotNull PdfPage page,
@@ -49,11 +52,11 @@ public class Header {
             pdfCanvas.addXObject(companyLogoObj, 52, 772, 44, false);
         }
 
-        cv.add(new Paragraph().add(new Text("Hartwig Medical").setFont(ReportResources.fontBold())
+        cv.add(new Paragraph().add(new Text("Hartwig Medical").setFont(reportResources.fontBold())
                         .setFontSize(11)
                         .setFontColor(ReportResources.PALETTE_BLUE))
-                .add(new Text(" Onco").setFont(ReportResources.fontRegular()).setFontSize(11).setFontColor(ReportResources.PALETTE_BLUE))
-                .add(new Text("Act").setFont(ReportResources.fontRegular())
+                .add(new Text(" Onco").setFont(reportResources.fontRegular()).setFontSize(11).setFontColor(ReportResources.PALETTE_BLUE))
+                .add(new Text("Act").setFont(reportResources.fontRegular())
                         .setFontSize(11)
                         .setFontColor(ReportResources.PALETTE_RED))
                 .setFixedPosition(230, 791, 300));
@@ -81,7 +84,7 @@ public class Header {
         }
     }
 
-    private static class ChapterPageCounter {
+    private class ChapterPageCounter {
 
         @NotNull
         private final String pdfTitle;
@@ -109,10 +112,10 @@ public class Header {
                 Canvas canvas = new Canvas(tpl, document);
 
                 if (!pdfTitle.isEmpty()) {
-                    canvas.add(new Paragraph(pdfTitle).addStyle(ReportResources.chapterTitleStyle()));
+                    canvas.add(new Paragraph(pdfTitle).addStyle(reportResources.chapterTitleStyle()));
                 }
 
-                canvas.add(new Paragraph(text).addStyle(ReportResources.chapterTitleStyle()));
+                canvas.add(new Paragraph(text).addStyle(reportResources.chapterTitleStyle()));
             }
         }
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Icon.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/Icon.java
@@ -64,7 +64,7 @@ public class Icon {
             { new DeviceRgb(110, 197, 213)};
 
     @NotNull
-    public static Text createLevelIcon(@NotNull String level) {
+    public static Text createLevelIcon(@NotNull ReportResources reportResources, @NotNull String level) {
         IconType iconType;
         switch (level.toUpperCase()) {
             case "A":
@@ -83,28 +83,28 @@ public class Icon {
                 return new Text(Strings.EMPTY);
         }
 
-        return createIcon(iconType);
+        return createIcon(reportResources, iconType);
     }
 
     @NotNull
-    public static Text createTreatmentIcon(@NotNull String treatmentName) {
+    public static Text createTreatmentIcon(@NotNull ReportResources reportResources, @NotNull String treatmentName) {
         int charCode = !treatmentName.isEmpty() ? (int) treatmentName.charAt(0) : 0;
         int colorIndex = charCode % TREATMENT_PALETTE.length;
 
-        return createIcon(IconType.TREATMENT, TREATMENT_PALETTE[colorIndex]);
+        return createIcon(reportResources, IconType.TREATMENT, TREATMENT_PALETTE[colorIndex]);
     }
 
     @NotNull
-    public static Text createIcon(@NotNull IconType iconType) {
-        return createIcon(iconType, iconType.defaultColor());
+    public static Text createIcon(@NotNull ReportResources reportResources, @NotNull IconType iconType) {
+        return createIcon(reportResources, iconType, iconType.defaultColor());
     }
 
     @NotNull
-    private static Text createIcon(@NotNull IconType iconType, @NotNull DeviceRgb color) {
+    private static Text createIcon(@NotNull ReportResources reportResources, @NotNull IconType iconType, @NotNull DeviceRgb color) {
         if (iconType == IconType.INVALID) {
             return new Text("");
         }
 
-        return new Text(iconType.text()).setFont(ReportResources.iconFont()).setFontColor(color);
+        return new Text(iconType.text()).setFont(reportResources.iconFont()).setFontColor(color);
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/ReportSignature.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/ReportSignature.java
@@ -14,16 +14,24 @@ import org.jetbrains.annotations.NotNull;
 
 public final class ReportSignature {
 
-    private ReportSignature() {
+    @NotNull
+    private final ReportResources reportResources;
+
+    private ReportSignature(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
+    }
+
+    public static ReportSignature create(@NotNull ReportResources reportResources) {
+        return new ReportSignature(reportResources);
     }
 
     @NotNull
-    public static Paragraph createEndOfReportIndication() {
-        return new Paragraph("— End of report —").setMarginTop(40).addStyle(ReportResources.smallBodyTextStyle());
+    public Paragraph createEndOfReportIndication() {
+        return new Paragraph("— End of report —").setMarginTop(40).addStyle(reportResources.smallBodyTextStyle());
     }
 
     @NotNull
-    public static Div createSignatureDiv(@NotNull String rvaLogoPath, @NotNull String signaturePath) throws IOException {
+    public Div createSignatureDiv(@NotNull String rvaLogoPath, @NotNull String signaturePath) throws IOException {
         Div div = new Div();
         div.setKeepTogether(true);
         div.setMarginTop(40);
@@ -37,10 +45,10 @@ public final class ReportSignature {
         }
 
         Paragraph signatureText =
-                new Paragraph().setFont(ReportResources.fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_BLACK);
+                new Paragraph().setFont(reportResources.fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_BLACK);
 
         signatureText.add(ReportResources.SIGNATURE_NAME + ",\n");
-        signatureText.add(new Text(ReportResources.SIGNATURE_TITLE).setFont(ReportResources.fontRegular()));
+        signatureText.add(new Text(ReportResources.SIGNATURE_TITLE).setFont(reportResources.fontRegular()));
         div.add(signatureText);
 
         try {
@@ -57,16 +65,16 @@ public final class ReportSignature {
     }
 
     @NotNull
-    public static Div createSignatureDivPanel(@NotNull String signaturePath) throws IOException {
+    public Div createSignatureDivPanel(@NotNull String signaturePath) throws IOException {
         Div div = new Div();
         div.setKeepTogether(true);
         div.setMarginTop(40);
 
         Paragraph signatureText =
-                new Paragraph().setFont(ReportResources.fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_BLACK);
+                new Paragraph().setFont(reportResources.fontBold()).setFontSize(10).setFontColor(ReportResources.PALETTE_BLACK);
 
         signatureText.add(ReportResources.SIGNATURE_NAME + ",\n");
-        signatureText.add(new Text(ReportResources.SIGNATURE_TITLE).setFont(ReportResources.fontRegular()));
+        signatureText.add(new Text(ReportResources.SIGNATURE_TITLE).setFont(reportResources.fontRegular()));
         div.add(signatureText);
 
         try {

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/SidePanel.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/SidePanel.java
@@ -25,10 +25,14 @@ public final class SidePanel {
     private static final float RECTANGLE_WIDTH = 170;
     private static final float RECTANGLE_HEIGHT_SHORT = 110;
 
-    private SidePanel() {
+    @NotNull
+    private final ReportResources reportResources;
+
+    public SidePanel(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
-    public static void renderSidePatientReport(@NotNull PdfPage page, @NotNull PatientReport patientReport, boolean fullHeight) {
+    public void renderSidePatientReport(@NotNull PdfPage page, @NotNull PatientReport patientReport, boolean fullHeight) {
         renderSidePanel(page,
                 patientReport.lamaPatientData(),
                 patientReport.diagnosticSiloPatientData(),
@@ -36,7 +40,7 @@ public final class SidePanel {
                 fullHeight);
     }
 
-    public static void renderSidePanelPanelReport(@NotNull PdfPage page, @NotNull PanelReport patientReport, boolean fullHeight) {
+    public void renderSidePanelPanelReport(@NotNull PdfPage page, @NotNull PanelReport patientReport, boolean fullHeight) {
         renderSidePanel(page,
                 patientReport.lamaPatientData(),
                 patientReport.diagnosticSiloPatientData(),
@@ -45,7 +49,7 @@ public final class SidePanel {
 
     }
 
-    public static void renderSidePanel(@NotNull PdfPage page, @NotNull PatientReporterData lamaPatientData, @Nullable PatientInformationResponse patientInformationData, @NotNull String reportDate,
+    public void renderSidePanel(@NotNull PdfPage page, @NotNull PatientReporterData lamaPatientData, @Nullable PatientInformationResponse patientInformationData, @NotNull String reportDate,
                                        boolean fullHeight) {
         PdfCanvas canvas = new PdfCanvas(page.getLastContentStream(), page.getResources(), page.getDocument());
         Rectangle pageSize = page.getPageSize();
@@ -122,7 +126,7 @@ public final class SidePanel {
     }
 
     @NotNull
-    private static Div createSidePanelDiv(int index, @NotNull String label, @NotNull String value) {
+    private Div createSidePanelDiv(int index, @NotNull String label, @NotNull String value) {
         float Y_START = 802;
         float VALUE_TEXT_Y_OFFSET = 18;
         float MAX_WIDTH = 120;
@@ -131,12 +135,12 @@ public final class SidePanel {
         div.setKeepTogether(true);
 
         float yPos = Y_START - index * ROW_SPACING;
-        div.add(new Paragraph(label.toUpperCase()).addStyle(ReportResources.sidePanelLabelStyle())
+        div.add(new Paragraph(label.toUpperCase()).addStyle(reportResources.sidePanelLabelStyle())
                 .setFixedPosition(CONTENT_X_START, yPos, MAX_WIDTH));
 
-        float valueFontSize = ReportResources.maxPointSizeForWidth(ReportResources.fontBold(), 11, 6, value, MAX_WIDTH);
+        float valueFontSize = ReportResources.maxPointSizeForWidth(reportResources.fontBold(), 11, 6, value, MAX_WIDTH);
         yPos -= VALUE_TEXT_Y_OFFSET;
-        div.add(new Paragraph(value).addStyle(ReportResources.sidePanelValueStyle().setFontSize(valueFontSize))
+        div.add(new Paragraph(value).addStyle(reportResources.sidePanelValueStyle().setFontSize(valueFontSize))
                 .setHeight(15)
                 .setFixedPosition(CONTENT_X_START, yPos, MAX_WIDTH)
                 .setFixedLeading(valueFontSize));

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/TableUtil.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/TableUtil.java
@@ -18,21 +18,24 @@ public final class TableUtil {
 
     public static final float TABLE_BOTTOM_MARGIN = 20;
     public static final float TABLE_BOTTOM_MARGIN_SUMMARY = 0;
+    @NotNull
+    private final ReportResources reportResources;
 
-    private TableUtil() {
+    public TableUtil(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
     @NotNull
-    public static Cell createTransparentCell(@NotNull String text) {
+    public Cell createTransparentCell(@NotNull String text) {
         return createTransparentCell(new Paragraph(text));
     }
 
     @NotNull
-    public static Cell createTransparentCell(@NotNull IBlockElement element) {
+    public Cell createTransparentCell(@NotNull IBlockElement element) {
         Cell cell = new Cell();
         cell.setBorder(Border.NO_BORDER);
         cell.setBorderBottom(Border.NO_BORDER);
-        cell.addStyle(ReportResources.tableContentStyle());
+        cell.addStyle(reportResources.tableContentStyle());
         cell.setKeepTogether(true);
         cell.add(element);
         return cell;
@@ -51,51 +54,51 @@ public final class TableUtil {
     }
 
     @NotNull
-    public static Table createNoConsentReportTable(@NotNull String tableTitle, @NotNull String peachUnreliable, float tableBottomMargin,
+    public Table createNoConsentReportTable(@NotNull String tableTitle, @NotNull String peachUnreliable, float tableBottomMargin,
             float contentWide) {
         Table table = TableUtil.createReportContentTable(new float[] { 1 }, new Cell[] {}, contentWide);
         table.setKeepTogether(true);
         table.setMarginBottom(tableBottomMargin);
-        table.addCell(TableUtil.createContentCell(new Paragraph(peachUnreliable)));
+        table.addCell(createContentCell(new Paragraph(peachUnreliable)));
         return createWrappingReportTable(tableTitle, null, table, tableBottomMargin);
     }
 
     @NotNull
-    public static Table createNoneReportTable(@NotNull String tableTitle, @Nullable String subTableTitle, float tableBottomMargin,
+    public Table createNoneReportTable(@NotNull String tableTitle, @Nullable String subTableTitle, float tableBottomMargin,
             float contentWide) {
         Cell headerCell;
         if (subTableTitle == null) {
             headerCell = new Cell().setBorder(Border.NO_BORDER)
-                    .add(new Paragraph(tableTitle).addStyle(ReportResources.sectionTitleStyle()
+                    .add(new Paragraph(tableTitle).addStyle(reportResources.sectionTitleStyle()
                             .setFontColor(ReportResources.PALETTE_LIGHT_GREY)));
         } else {
             headerCell = new Cell().setBorder(Border.NO_BORDER)
-                    .add(new Paragraph(tableTitle).addStyle(ReportResources.sectionTitleStyle()
+                    .add(new Paragraph(tableTitle).addStyle(reportResources.sectionTitleStyle()
                             .setFontColor(ReportResources.PALETTE_LIGHT_GREY)))
-                    .add(new Paragraph(subTableTitle).addStyle(ReportResources.sectionSubTitleStyle()
+                    .add(new Paragraph(subTableTitle).addStyle(reportResources.sectionSubTitleStyle()
                             .setFontColor(ReportResources.PALETTE_LIGHT_GREY)));
         }
 
-        Table table = TableUtil.createReportContentTable(new float[] { 1 }, new Cell[] { headerCell }, contentWide);
+        Table table = createReportContentTable(new float[] { 1 }, new Cell[] { headerCell }, contentWide);
         table.setKeepTogether(true);
         table.setMarginBottom(tableBottomMargin);
-        table.addCell(TableUtil.createDisabledContentCell(new Paragraph(Formats.NONE_STRING)));
+        table.addCell(createDisabledContentCell(new Paragraph(Formats.NONE_STRING)));
 
         return table;
     }
 
     @NotNull
-    public static Table createWrappingReportTable(@NotNull String tableTitle, @Nullable String subtitle, @NotNull Table contentTable,
+    public Table createWrappingReportTable(@NotNull String tableTitle, @Nullable String subtitle, @NotNull Table contentTable,
             float tableBottomMargin) {
         contentTable.addFooterCell(new Cell(1, contentTable.getNumberOfColumns()).setBorder(Border.NO_BORDER)
                         .setPaddingTop(5)
                         .setPaddingBottom(5)
-                        .add(new Paragraph("The table continues on the next page".toUpperCase()).addStyle(ReportResources.subTextStyle())))
+                        .add(new Paragraph("The table continues on the next page".toUpperCase()).addStyle(reportResources.subTextStyle())))
                 .setSkipLastFooter(true);
 
         Table continuedWrapTable = new Table(1).setMinWidth(contentTable.getWidth())
                 .addHeaderCell(new Cell().setBorder(Border.NO_BORDER)
-                        .add(new Paragraph("Continued from the previous page".toUpperCase()).addStyle(ReportResources.subTextStyle())))
+                        .add(new Paragraph("Continued from the previous page".toUpperCase()).addStyle(reportResources.subTextStyle())))
                 .setSkipFirstHeader(true)
                 .addCell(new Cell().add(contentTable).setPadding(0).setBorder(Border.NO_BORDER));
 
@@ -104,77 +107,77 @@ public final class TableUtil {
                     .setMarginBottom(tableBottomMargin)
                     .addHeaderCell(new Cell().setBorder(Border.NO_BORDER)
                             .setPadding(0)
-                            .add(new Paragraph(tableTitle).addStyle(ReportResources.sectionTitleStyle())))
+                            .add(new Paragraph(tableTitle).addStyle(reportResources.sectionTitleStyle())))
                     .addCell(new Cell().add(continuedWrapTable).setPadding(0).setBorder(Border.NO_BORDER));
         } else {
             return new Table(1).setMinWidth(contentTable.getWidth())
                     .setMarginBottom(tableBottomMargin)
                     .addHeaderCell(new Cell().setBorder(Border.NO_BORDER)
                             .setPadding(0)
-                            .add(new Paragraph(tableTitle).addStyle(ReportResources.sectionTitleStyle()))
-                            .add(new Paragraph(subtitle).addStyle(ReportResources.sectionSubTitleStyle())))
+                            .add(new Paragraph(tableTitle).addStyle(reportResources.sectionTitleStyle()))
+                            .add(new Paragraph(subtitle).addStyle(reportResources.sectionSubTitleStyle())))
                     .addCell(new Cell().add(continuedWrapTable).setPadding(0).setBorder(Border.NO_BORDER));
         }
     }
 
     @NotNull
-    public static Cell createHeaderCell(@NotNull String text) {
+    public Cell createHeaderCell(@NotNull String text) {
         return createHeaderCell(text, 1);
     }
 
     @NotNull
-    public static Cell createHeaderCell(@NotNull String text, int colSpan) {
+    public Cell createHeaderCell(@NotNull String text, int colSpan) {
         return createHeaderCell(colSpan).add(new Paragraph(text.toUpperCase()));
     }
 
     @NotNull
-    private static Cell createHeaderCell(int colSpan) {
+    private Cell createHeaderCell(int colSpan) {
         Cell c = new Cell(1, colSpan);
         c.setHeight(23); // Set fixed height to create consistent spacing between table title and header
         c.setBorder(Border.NO_BORDER);
         c.setVerticalAlignment(VerticalAlignment.BOTTOM);
-        c.addStyle(ReportResources.tableHeaderStyle());
+        c.addStyle(reportResources.tableHeaderStyle());
         return c;
     }
 
     @NotNull
-    public static Cell createContentCell(@NotNull String text) {
+    public Cell createContentCell(@NotNull String text) {
         return createContentCell(new Paragraph(text));
     }
 
     @NotNull
-    public static Cell createContentCell(@NotNull IBlockElement element) {
+    public Cell createContentCell(@NotNull IBlockElement element) {
         Cell c = new Cell();
         c.setBorder(Border.NO_BORDER);
         c.setBorderBottom(new SolidBorder(ReportResources.PALETTE_MID_GREY, 0.25f));
-        c.addStyle(ReportResources.tableContentStyle());
+        c.addStyle(reportResources.tableContentStyle());
         c.setKeepTogether(true);
         c.add(element);
         return c;
     }
 
     @NotNull
-    public static Cell createContentCellPurityPloidy(@NotNull String text) {
+    public Cell createContentCellPurityPloidy(@NotNull String text) {
         return createContentCellPurityPloidy(new Paragraph(text));
     }
 
     @NotNull
-    public static Cell createContentCellPurityPloidy(@NotNull IBlockElement element) {
+    public Cell createContentCellPurityPloidy(@NotNull IBlockElement element) {
         Cell c = new Cell();
         c.setBorder(Border.NO_BORDER);
         c.setBorderBottom(new SolidBorder(ReportResources.PALETTE_MID_GREY, 0.25f));
-        c.addStyle(ReportResources.dataHighlightStyle());
+        c.addStyle(reportResources.dataHighlightStyle());
         c.setKeepTogether(true);
         c.add(element);
         return c;
     }
 
     @NotNull
-    private static Cell createDisabledContentCell(@NotNull IBlockElement element) {
+    private Cell createDisabledContentCell(@NotNull IBlockElement element) {
         Cell c = new Cell();
         c.setBorder(Border.NO_BORDER);
         c.setBorderBottom(new SolidBorder(ReportResources.PALETTE_LIGHT_GREY, 0.25f));
-        c.addStyle(ReportResources.tableContentStyle().setFontColor(ReportResources.PALETTE_LIGHT_GREY));
+        c.addStyle(reportResources.tableContentStyle().setFontColor(ReportResources.PALETTE_LIGHT_GREY));
         c.setKeepTogether(true);
         c.add(element);
         return c;

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/TumorLocationAndTypeTable.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/components/TumorLocationAndTypeTable.java
@@ -13,21 +13,24 @@ import java.util.Optional;
 
 public final class TumorLocationAndTypeTable {
 
-    private TumorLocationAndTypeTable() {
+    private final ReportResources reportResources;
+
+    public TumorLocationAndTypeTable(ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
     @NotNull
-    public static Table createTumorLocation(@Nullable TumorType tumorType, float width) {
+    public Table createTumorLocation(@Nullable TumorType tumorType, float width) {
         Table table = new Table(UnitValue.createPercentArray(new float[] { 2, 2 }));
         table.setWidth(width);
 
-        table.addCell(TableUtil.createLayoutCell().add(new Paragraph("PRIMARY TUMOR LOCATION").addStyle(ReportResources.subTextStyle())));
-        table.addCell(TableUtil.createLayoutCell().add(new Paragraph("PRIMARY TUMOR TYPE").addStyle(ReportResources.subTextStyle())));
+        table.addCell(TableUtil.createLayoutCell().add(new Paragraph("PRIMARY TUMOR LOCATION").addStyle(reportResources.subTextStyle())));
+        table.addCell(TableUtil.createLayoutCell().add(new Paragraph("PRIMARY TUMOR TYPE").addStyle(reportResources.subTextStyle())));
 
         String tumorLocation = Optional.ofNullable(tumorType).map(TumorType::getLocation).orElse("");
-        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(tumorLocation)));
+        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(reportResources, tumorLocation)));
         String type = Optional.ofNullable(tumorType).map(TumorType::getType).orElse("");
-        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(type)));
+        table.addCell(TableUtil.createLayoutCell().add(DataLabel.createDataLabel(reportResources, type)));
 
         return table;
     }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/EvidenceItems.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/EvidenceItems.java
@@ -19,14 +19,15 @@ import org.jetbrains.annotations.NotNull;
 public final class EvidenceItems {
 
     private static final String NONE = "None";
+    private final ReportResources reportResources;
 
-    private EvidenceItems() {
+    public EvidenceItems(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
     }
 
 
-
     @NotNull
-    public static Paragraph createLinksPublications(@NotNull Set<String> evidenceUrls) {
+    public Paragraph createLinksPublications(@NotNull Set<String> evidenceUrls) {
         Paragraph paragraphPublications = new Paragraph();
         int number = 0;
         for (String url : evidenceUrls) {
@@ -37,7 +38,7 @@ public final class EvidenceItems {
                     paragraphPublications.add(new Text(", "));
                 }
 
-                paragraphPublications.add(new Text(Integer.toString(number)).addStyle(ReportResources.urlStyle())
+                paragraphPublications.add(new Text(Integer.toString(number)).addStyle(reportResources.urlStyle())
                         .setAction(PdfAction.createURI(url))).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
             }
         }
@@ -46,7 +47,7 @@ public final class EvidenceItems {
     }
 
     @NotNull
-    public static Paragraph createLinksSource(@NotNull Map<String, String> sourceUrls) {
+    public Paragraph createLinksSource(@NotNull Map<String, String> sourceUrls) {
         Paragraph paragraphSources = new Paragraph();
 
         for (Map.Entry<String, String> entry : sourceUrls.entrySet()) {
@@ -55,9 +56,9 @@ public final class EvidenceItems {
             }
 
             if (entry.getValue().isEmpty()) {
-                paragraphSources.add(new Text(entry.getKey()).addStyle(ReportResources.subTextStyle()));
+                paragraphSources.add(new Text(entry.getKey()).addStyle(reportResources.subTextStyle()));
             } else {
-                paragraphSources.add(new Text(entry.getKey()).addStyle(ReportResources.urlStyle())
+                paragraphSources.add(new Text(entry.getKey()).addStyle(reportResources.urlStyle())
                         .setAction(PdfAction.createURI(entry.getValue()))).setFixedLeading(ReportResources.BODY_TEXT_LEADING);
             }
         }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/GeneFusions.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/GeneFusions.java
@@ -18,8 +18,14 @@ import com.itextpdf.layout.element.Paragraph;
 import org.jetbrains.annotations.NotNull;
 
 public final class GeneFusions {
+    
+    private final TableUtil tableUtil;
+    @NotNull
+    private final ReportResources reportResources;
 
-    private GeneFusions() {
+    public GeneFusions(@NotNull ReportResources reportResources) {
+        this.reportResources = reportResources;
+        this.tableUtil = new TableUtil(reportResources);
     }
 
     @NotNull
@@ -47,18 +53,18 @@ public final class GeneFusions {
     }
 
     @NotNull
-    public static Cell fusionContentType(@NotNull LinxFusionType type, @NotNull String geneName, @NotNull String transcript) {
+    public Cell fusionContentType(@NotNull LinxFusionType type, @NotNull String geneName, @NotNull String transcript) {
         if (type.equals(LinxFusionType.IG_PROMISCUOUS) || type.equals(LinxFusionType.IG_KNOWN_PAIR)) {
             if (geneName.startsWith("@IG")) {
-                return TableUtil.createContentCell(new Paragraph(transcript));
+                return tableUtil.createContentCell(new Paragraph(transcript));
             } else {
-                return TableUtil.createContentCell(new Paragraph(transcript))
-                        .addStyle(ReportResources.dataHighlightLinksStyle())
+                return tableUtil.createContentCell(new Paragraph(transcript))
+                        .addStyle(reportResources.dataHighlightLinksStyle())
                         .setAction(PdfAction.createURI(GeneFusions.transcriptUrl(transcript)));
             }
         } else {
-            return TableUtil.createContentCell(new Paragraph(transcript))
-                    .addStyle(ReportResources.dataHighlightLinksStyle())
+            return tableUtil.createContentCell(new Paragraph(transcript))
+                    .addStyle(reportResources.dataHighlightLinksStyle())
                     .setAction(PdfAction.createURI(GeneFusions.transcriptUrl(transcript)));
         }
     }

--- a/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/cfreport/ReportResourcesTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/cfreport/ReportResourcesTest.java
@@ -8,8 +8,9 @@ public class ReportResourcesTest {
 
     @Test
     public void canLoadFonts() {
-        assertNotNull(ReportResources.fontRegular());
-        assertNotNull(ReportResources.fontBold());
-        assertNotNull(ReportResources.iconFont());
+        ReportResources reportResources = ReportResources.create();
+        assertNotNull(reportResources.fontRegular());
+        assertNotNull(reportResources.fontBold());
+        assertNotNull(reportResources.iconFont());
     }
 }


### PR DESCRIPTION
Just as in Actin-24, we now use a single instance of ReportResources per report. This instance contains one font object per font.

Before this, one static instance was used that created a new font object per cell with a static factory method.

This update significantly reduces the size of the resulting PDF.