### PR TITLE
Dev 3608

### DIFF
--- a/patient-reporter/pom.xml
+++ b/patient-reporter/pom.xml
@@ -77,8 +77,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>com.hartwig.oncoact.patientreporter.PatientReporterApplication
-                            </mainClass>
+                            <mainClass>com.hartwig.oncoact.patientreporter.ReporterApplication</mainClass>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>

--- a/patient-reporter/run-docker.properties
+++ b/patient-reporter/run-docker.properties
@@ -9,6 +9,7 @@ udi_di=(01)8720299486058(8012)v5.33-1.0
 orange_json=/in/orange/orange.json
 cuppa_plot=/in/orange/cuppa-plot.png
 purple_circos_plot=/in/orange/purple-circos-plot.png
+panel_vcf_name=/in/purple/purple.vcf
 lama_json=/in/lama/patient-reporter.json
 protect_evidence_tsv=/in/protect/protect.tsv
 rose_tsv=/in/rose/rose.txt

--- a/patient-reporter/run-docker.properties
+++ b/patient-reporter/run-docker.properties
@@ -9,7 +9,6 @@ udi_di=(01)8720299486058(8012)v5.33-1.0
 orange_json=/in/orange/orange.json
 cuppa_plot=/in/orange/cuppa-plot.png
 purple_circos_plot=/in/orange/purple-circos-plot.png
-panel_vcf_name=/in/purple/purple.vcf
 lama_json=/in/lama/patient-reporter.json
 protect_evidence_tsv=/in/protect/protect.tsv
 rose_tsv=/in/rose/rose.txt

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelData.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelData.java
@@ -1,5 +1,7 @@
 package com.hartwig.oncoact.patientreporter;
 
+import java.util.Optional;
+
 import com.hartwig.lama.client.model.PatientReporterData;
 import com.hartwig.silo.diagnostic.client.model.PatientInformationResponse;
 
@@ -19,4 +21,11 @@ public interface PanelData {
 
     @NotNull
     String logoCompanyPath();
+
+    @NotNull
+    Optional<String> comments();
+
+    boolean correctedReport();
+
+    boolean correctedReportExtern();
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterApplication.java
@@ -3,13 +3,14 @@ package com.hartwig.oncoact.patientreporter;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Optional;
 
 import com.hartwig.lama.client.model.PatientReporterData;
 import com.hartwig.oncoact.parser.CliAndPropertyParser;
 import com.hartwig.oncoact.patientreporter.cfreport.CFReportWriter;
+import com.hartwig.oncoact.patientreporter.correction.Correction;
 import com.hartwig.oncoact.patientreporter.diagnosticsilo.DiagnosticSiloJson;
 import com.hartwig.oncoact.patientreporter.lama.LamaJson;
-import com.hartwig.oncoact.patientreporter.panel.ImmutableQCFailPanelReportData;
 import com.hartwig.oncoact.patientreporter.panel.PanelFailReport;
 import com.hartwig.oncoact.patientreporter.panel.PanelFailReporter;
 import com.hartwig.oncoact.patientreporter.panel.PanelReporter;
@@ -75,9 +76,7 @@ public class PanelReporterApplication {
 
     private void generatePanelAnalysedReport() throws IOException {
         PanelReporter reporter = new PanelReporter(buildBasePanelReportData(config), reportDate);
-        com.hartwig.oncoact.patientreporter.panel.PanelReport report = reporter.run(config.comments(),
-                config.isCorrectedReport(),
-                config.isCorrectedReportExtern(),
+        com.hartwig.oncoact.patientreporter.panel.PanelReport report = reporter.run(
                 config.expectedPipelineVersion(),
                 config.overridePipelineVersion(),
                 config.pipelineVersionFile(),
@@ -98,11 +97,7 @@ public class PanelReporterApplication {
 
     private void generatePanelQCFail() throws IOException {
         PanelFailReporter reporter = new PanelFailReporter(buildBasePanelReportData(config), reportDate);
-        PanelFailReport report = reporter.run(config.comments(),
-                config.isCorrectedReport(),
-                config.isCorrectedReportExtern(),
-                config.panelQcFailReason(),
-                config.sampleFailReasonComment());
+        PanelFailReport report = reporter.run(config.panelQcFailReason(), config.sampleFailReasonComment());
 
         ReportWriter reportWriter = CFReportWriter.createProductionReportWriter();
         String outputFilePath = generateOutputFilePathForPanelResultReport(config.outputDirReport(), report);
@@ -127,12 +122,17 @@ public class PanelReporterApplication {
 
         PatientReporterData lamaPatientData = LamaJson.read(config.lamaJson());
         PatientInformationResponse diagnosticPatientData = DiagnosticSiloJson.read(config.diagnosticSiloJson());
+        var correctionJson = config.correctionJson();
+        var correction = correctionJson != null ? Correction.read(correctionJson) : null;
 
-        return ImmutableQCFailPanelReportData.builder()
+        return QCFailPanelReportData.builder()
                 .lamaPatientData(lamaPatientData)
                 .diagnosticSiloPatientData(diagnosticPatientData)
                 .signaturePath(config.signature())
                 .logoCompanyPath(config.companyLogo())
+                .comments(Optional.ofNullable(correction).map(Correction::comments))
+                .correctedReport(Optional.ofNullable(correction).map(Correction::isCorrectedReport).orElse(false))
+                .correctedReportExtern(Optional.ofNullable(correction).map(Correction::isCorrectedReportExtern).orElse(false))
                 .build();
     }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterApplication.java
@@ -36,7 +36,7 @@ public class PanelReporterApplication {
     //                public static final String VERSION = "8.0";
 
     public static void main(@NotNull String[] args) throws IOException {
-        LOGGER.info("Running patient reporter v{}", VERSION);
+        LOGGER.info("Running panel reporter v{}", VERSION);
 
         Options options = PanelReporterConfig.createOptions();
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterConfig.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterConfig.java
@@ -1,5 +1,7 @@
 package com.hartwig.oncoact.patientreporter;
 
+import static com.hartwig.oncoact.patientreporter.ReporterApplication.PANEL;
+
 import java.io.File;
 import java.nio.file.Files;
 
@@ -56,6 +58,7 @@ public interface PanelReporterConfig {
     static Options createOptions() {
         Options options = new Options();
 
+        options.addOption(PANEL, false, "Flag to go into panel mode");
         options.addOption(OUTPUT_DIRECTORY_REPORT, true, "Path to where the PDF report will be written to.");
         options.addOption(OUTPUT_DIRECTORY_DATA, true, "Path to where the data of the report will be written to.");
 

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterConfig.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PanelReporterConfig.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Value.Immutable
-@Value.Style(passAnnotations = {NotNull.class, Nullable.class})
+@Value.Style(passAnnotations = { NotNull.class, Nullable.class })
 public interface PanelReporterConfig {
 
     Logger LOGGER = LogManager.getLogger(PanelReporterConfig.class);
@@ -41,9 +41,8 @@ public interface PanelReporterConfig {
     String IS_DIAGNOSTIC = "is_diagnostic";
 
     // Some additional optional params and flags
-    String COMMENTS = "comments";
-    String CORRECTED_REPORT = "corrected_report";
-    String CORRECTED_REPORT_EXTERN = "corrected_report_extern";
+    String HAS_CORRECTIONS = "has_corrections";
+    String CORRECTION_JSON = "correction_json";
     String LOG_DEBUG = "log_debug";
     String ONLY_CREATE_PDF = "only_create_pdf";
 
@@ -75,9 +74,8 @@ public interface PanelReporterConfig {
         options.addOption(IS_DIAGNOSTIC, false, "If provided, use diagnostic patient data ");
         options.addOption(DIAGNOSTIC_SILO_JSON, true, "If provided, the path towards the diagnostic silo json of the patient information");
 
-        options.addOption(COMMENTS, true, "Additional comments to be added to the report (optional).");
-        options.addOption(CORRECTED_REPORT, false, "If provided, generate a corrected report with corrected name");
-        options.addOption(CORRECTED_REPORT_EXTERN, false, "If provided, generate a corrected report with intern/extern correction");
+        options.addOption(HAS_CORRECTIONS, false, "If provided, expect a correction json.");
+        options.addOption(CORRECTION_JSON, true, "If provided, the path towards a correction json.");
 
         options.addOption(LOG_DEBUG, false, "If provided, set the log level to debug rather than default.");
         options.addOption(ONLY_CREATE_PDF, false, "If provided, just the PDF will be generated and no additional data will be updated.");
@@ -120,11 +118,7 @@ public interface PanelReporterConfig {
     PanelFailReason panelQcFailReason();
 
     @Nullable
-    String comments();
-
-    boolean isCorrectedReport();
-
-    boolean isCorrectedReportExtern();
+    String correctionJson();
 
     boolean onlyCreatePDF();
 
@@ -167,6 +161,11 @@ public interface PanelReporterConfig {
             panelVCFFile = nonOptionalValue(cmd, PANEL_VCF_NAME);
         }
 
+        String correctionJson = null;
+        if (cmd.hasOption(HAS_CORRECTIONS)) {
+            correctionJson = nonOptionalFile(cmd, CORRECTION_JSON);
+        }
+
         return ImmutablePanelReporterConfig.builder()
                 .outputDirReport(nonOptionalDir(cmd, OUTPUT_DIRECTORY_REPORT))
                 .outputDirData(nonOptionalDir(cmd, OUTPUT_DIRECTORY_DATA))
@@ -178,9 +177,7 @@ public interface PanelReporterConfig {
                 .panelVCFname(panelVCFFile)
                 .lamaJson(nonOptionalFile(cmd, LAMA_JSON))
                 .diagnosticSiloJson(nonOptionalFile(cmd, DIAGNOSTIC_SILO_JSON))
-                .comments(cmd.getOptionValue(COMMENTS))
-                .isCorrectedReport(cmd.hasOption(CORRECTED_REPORT))
-                .isCorrectedReportExtern(cmd.hasOption(CORRECTED_REPORT_EXTERN))
+                .correctionJson(correctionJson)
                 .onlyCreatePDF(cmd.hasOption(ONLY_CREATE_PDF))
                 .requirePipelineVersionFile(requirePipelineVersion)
                 .pipelineVersionFile(pipelineVersion)

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterApplication.java
@@ -16,7 +16,6 @@ import com.hartwig.oncoact.patientreporter.qcfail.QCFailReporter;
 import com.hartwig.oncoact.patientreporter.reportingdb.ReportingDb;
 import com.hartwig.oncoact.util.Formats;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -30,8 +29,6 @@ public class PatientReporterApplication {
 
     public static final String VERSION = PatientReporterApplication.class.getPackage().getImplementationVersion();
 
-    static final String PANEL = "panel";
-
     // Uncomment this line when generating an example report using CFReportWriterTest
     //  public static final String VERSION = "8.0";
 
@@ -40,23 +37,17 @@ public class PatientReporterApplication {
 
         Options options = PatientReporterConfig.createOptions();
 
+        PatientReporterConfig config;
         try {
-            var cmd = new CliAndPropertyParser().parse(options, args);
-            boolean isPanel = cmd.hasOption(PANEL);
-            if (isPanel) {
-                var config = PanelReporterConfig.createConfig(cmd);
-                LOGGER.info("Panel reporter config is: {}", config);
-                new PanelReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
-            } else {
-                var config = PatientReporterConfig.createConfig(cmd);
-                LOGGER.info("Patient reporter config is: {}", config);
-                new PatientReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
-            }
+            config = PatientReporterConfig.createConfig(new CliAndPropertyParser().parse(options, args));
         } catch (ParseException exception) {
             LOGGER.warn(exception);
             new HelpFormatter().printHelp("PatientReporter", options);
             throw new IllegalArgumentException("Unexpected error, check inputs");
         }
+
+        LOGGER.info("Patient reporter config is: {}", config);
+        new PatientReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
     }
 
     @NotNull

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterApplication.java
@@ -16,6 +16,7 @@ import com.hartwig.oncoact.patientreporter.qcfail.QCFailReporter;
 import com.hartwig.oncoact.patientreporter.reportingdb.ReportingDb;
 import com.hartwig.oncoact.util.Formats;
 
+import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -29,6 +30,8 @@ public class PatientReporterApplication {
 
     public static final String VERSION = PatientReporterApplication.class.getPackage().getImplementationVersion();
 
+    static final String PANEL = "panel";
+
     // Uncomment this line when generating an example report using CFReportWriterTest
     //  public static final String VERSION = "8.0";
 
@@ -37,17 +40,23 @@ public class PatientReporterApplication {
 
         Options options = PatientReporterConfig.createOptions();
 
-        PatientReporterConfig config = null;
         try {
-            config = PatientReporterConfig.createConfig(new CliAndPropertyParser().parse(options, args));
+            var cmd = new CliAndPropertyParser().parse(options, args);
+            boolean isPanel = cmd.hasOption(PANEL);
+            if (isPanel) {
+                var config = PanelReporterConfig.createConfig(cmd);
+                LOGGER.info("Panel reporter config is: {}", config);
+                new PanelReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
+            } else {
+                var config = PatientReporterConfig.createConfig(cmd);
+                LOGGER.info("Patient reporter config is: {}", config);
+                new PatientReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
+            }
         } catch (ParseException exception) {
             LOGGER.warn(exception);
             new HelpFormatter().printHelp("PatientReporter", options);
-            System.exit(1);
+            throw new IllegalArgumentException("Unexpected error, check inputs");
         }
-
-        LOGGER.info("Patient reporter config is: {}", config);
-        new PatientReporterApplication(config, Formats.formatDate(LocalDate.now())).run();
     }
 
     @NotNull

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterConfig.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/PatientReporterConfig.java
@@ -1,5 +1,7 @@
 package com.hartwig.oncoact.patientreporter;
 
+import static com.hartwig.oncoact.patientreporter.ReporterApplication.PANEL;
+
 import java.io.File;
 import java.nio.file.Files;
 
@@ -69,6 +71,7 @@ public interface PatientReporterConfig {
     static Options createOptions() {
         Options options = new Options();
 
+        options.addOption(PANEL, false, "Flag to go into panel mode");
         options.addOption(OUTPUT_DIRECTORY_REPORT, true, "Path to where the PDF report will be written to.");
         options.addOption(OUTPUT_DIRECTORY_DATA, true, "Path to where the data of the report will be written to.");
 
@@ -182,6 +185,10 @@ public interface PatientReporterConfig {
         if (cmd.hasOption(LOG_DEBUG)) {
             Configurator.setRootLevel(Level.DEBUG);
             LOGGER.debug("Switched root level logging to DEBUG");
+        }
+
+        if (cmd.hasOption(PANEL)) {
+            throw new IllegalStateException("Unexpected argument to run panel in patient reporter mode");
         }
 
         boolean isQCFail = cmd.hasOption(QC_FAIL);

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/ReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/ReporterApplication.java
@@ -1,7 +1,7 @@
 package com.hartwig.oncoact.patientreporter;
 
 import java.io.IOException;
-import java.util.stream.Stream;
+import java.util.Arrays;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -9,7 +9,7 @@ public class ReporterApplication {
     public static final String PANEL = "panel";
 
     public static void main(@NotNull String[] args) throws IOException {
-        if (Stream.of(args).anyMatch(arg -> arg.endsWith(PANEL))) {
+        if (Arrays.asList(args).contains("-" + PANEL)) {
             PanelReporterApplication.main(args);
         } else {
             PatientReporterApplication.main(args);

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/ReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/ReporterApplication.java
@@ -1,0 +1,18 @@
+package com.hartwig.oncoact.patientreporter;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ReporterApplication {
+    public static final String PANEL = "panel";
+
+    public static void main(@NotNull String[] args) throws IOException {
+        if (Stream.of(args).anyMatch(arg -> arg.endsWith(PANEL))) {
+            PanelReporterApplication.main(args);
+        } else {
+            PatientReporterApplication.main(args);
+        }
+    }
+}

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReport.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReport.java
@@ -13,6 +13,10 @@ import org.jetbrains.annotations.Nullable;
 @Value.Style(passAnnotations = {NotNull.class, Nullable.class})
 public abstract class PanelFailReport implements PanelReport {
 
+    static ImmutablePanelFailReport.Builder builder() {
+        return ImmutablePanelFailReport.builder();
+    }
+
     @Override
     @NotNull
     public abstract String qsFormNumber();

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReporter.java
@@ -22,8 +22,7 @@ public class PanelFailReporter {
     }
 
     @NotNull
-    public PanelFailReport run(@Nullable String comments, boolean correctedReport, boolean correctedReportExtern,
-            @Nullable PanelFailReason reason, @Nullable String sampleFailReasonComment) throws IOException {
+    public PanelFailReport run(@Nullable PanelFailReason reason, @Nullable String sampleFailReasonComment) throws IOException {
         assert reason != null;
 
         FailedReason failedDatabase = ImmutableFailedReason.builder()
@@ -34,9 +33,9 @@ public class PanelFailReporter {
 
         return ImmutablePanelFailReport.builder()
                 .qsFormNumber(reason.qcFormNumber())
-                .comments(Optional.ofNullable(comments))
-                .isCorrectedReport(correctedReport)
-                .isCorrectedReportExtern(correctedReportExtern)
+                .comments(reportData.comments())
+                .isCorrectedReport(reportData.correctedReport())
+                .isCorrectedReportExtern(reportData.correctedReportExtern())
                 .signaturePath(reportData.signaturePath())
                 .logoCompanyPath(reportData.logoCompanyPath())
                 .reportDate(reportDate)

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelFailReporter.java
@@ -1,7 +1,6 @@
 package com.hartwig.oncoact.patientreporter.panel;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import com.hartwig.oncoact.patientreporter.failedreasondb.FailedReason;
 import com.hartwig.oncoact.patientreporter.failedreasondb.ImmutableFailedReason;
@@ -31,7 +30,7 @@ public class PanelFailReporter {
                 .sampleFailReasonComment(sampleFailReasonComment)
                 .build();
 
-        return ImmutablePanelFailReport.builder()
+        return PanelFailReport.builder()
                 .qsFormNumber(reason.qcFormNumber())
                 .comments(reportData.comments())
                 .isCorrectedReport(reportData.correctedReport())

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelReporter.java
@@ -42,6 +42,7 @@ public class PanelReporter {
                 .isCorrectedReportExtern(reportData.correctedReportExtern())
                 .signaturePath(reportData.signaturePath())
                 .logoCompanyPath(reportData.logoCompanyPath())
+                .lamaPatientData(reportData.lamaPatientData())
                 .reportDate(reportDate)
                 .isWGSReport(false)
                 .build();

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/PanelReporter.java
@@ -23,9 +23,8 @@ public class PanelReporter {
     }
 
     @NotNull
-    public PanelReport run(@Nullable String comments, boolean correctedReport,
-            boolean correctedReportExtern, @NotNull String expectedPipelineVersion, boolean overridePipelineVersion,
-            @Nullable String pipelineVersionFile, boolean requirePipelineVersionFile, @NotNull String panelVCFname) throws IOException {
+    public PanelReport run(@NotNull String expectedPipelineVersion, boolean overridePipelineVersion, @Nullable String pipelineVersionFile,
+            boolean requirePipelineVersionFile, @NotNull String panelVCFname) throws IOException {
 
         String pipelineVersion = null;
         if (requirePipelineVersionFile) {
@@ -38,9 +37,9 @@ public class PanelReporter {
                 .qsFormNumber(QsFormNumber.FOR_344.display())
                 .pipelineVersion(pipelineVersion)
                 .VCFFilename(panelVCFname)
-                .comments(Optional.ofNullable(comments))
-                .isCorrectedReport(correctedReport)
-                .isCorrectedReportExtern(correctedReportExtern)
+                .comments(reportData.comments())
+                .isCorrectedReport(reportData.correctedReport())
+                .isCorrectedReportExtern(reportData.correctedReportExtern())
                 .signaturePath(reportData.signaturePath())
                 .logoCompanyPath(reportData.logoCompanyPath())
                 .reportDate(reportDate)

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/QCFailPanelReportData.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/panel/QCFailPanelReportData.java
@@ -9,5 +9,7 @@ import org.jetbrains.annotations.Nullable;
 @Value.Immutable
 @Value.Style(passAnnotations = {NotNull.class, Nullable.class})
 public abstract class QCFailPanelReportData implements PanelData {
-
+    public static ImmutableQCFailPanelReportData.Builder builder() {
+        return ImmutableQCFailPanelReportData.builder();
+    }
 }


### PR DESCRIPTION
- Allow starting panel and patient reporter from the same (default) main method.
- Update the panel corrections options to the new corrections datatype used in the patient reporter.
- Load the panel reporter default options as part of the docker image.