### PR TITLE
INFRA-453: Port ONCOACT to ORANGE datamodel 2.3.0

### DIFF
--- a/common/src/main/java/com/hartwig/oncoact/disruption/GeneDisruptionFactory.java
+++ b/common/src/main/java/com/hartwig/oncoact/disruption/GeneDisruptionFactory.java
@@ -134,13 +134,14 @@ public final class GeneDisruptionFactory {
         return pairedMap;
     }
 
+    @VisibleForTesting
     @NotNull
-    private static String rangeField(@NotNull Pair<LinxBreakend, LinxBreakend> pairedBreakend) {
+    static String rangeField(@NotNull Pair<LinxBreakend, LinxBreakend> pairedBreakend) {
         LinxBreakend primary = pairedBreakend.getLeft();
         LinxBreakend secondary = pairedBreakend.getRight();
 
         if (secondary == null) {
-            return exonDescription(primary.exonUp(), primary.exonDown()) + (isUpstream(primary) ? " Upstream" : " Downstream");
+            return exonDescription(primary.exonUp(), primary.exonDown()) + (isDisruptedUpstream(primary) ? " Upstream" : " Downstream");
         } else {
             return exonDescription(primary.exonUp(), primary.exonDown()) + " -> " + exonDescription(secondary.exonUp(),
                     secondary.exonDown());
@@ -162,8 +163,8 @@ public final class GeneDisruptionFactory {
         return String.format("ERROR up=%d, down=%d", exonUp, exonDown);
     }
 
-    private static boolean isUpstream(@NotNull LinxBreakend breakend) {
-        return breakend.geneOrientation().equals(BREAKEND_ORIENTATION_UPSTREAM);
+    private static boolean isDisruptedUpstream(@NotNull LinxBreakend breakend) {
+        return !breakend.geneOrientation().equals(BREAKEND_ORIENTATION_UPSTREAM);
     }
 
     private static class SvAndTranscriptKey {

--- a/common/src/main/java/com/hartwig/oncoact/disruption/GeneDisruptionFactory.java
+++ b/common/src/main/java/com/hartwig/oncoact/disruption/GeneDisruptionFactory.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 public final class GeneDisruptionFactory {
 
     private static final Logger LOGGER = LogManager.getLogger(GeneDisruptionFactory.class);
+    private static final String BREAKEND_ORIENTATION_UPSTREAM = "Upstream";
 
     private GeneDisruptionFactory() {
     }
@@ -44,10 +45,10 @@ public final class GeneDisruptionFactory {
                     LOGGER.warn("The disrupted copy number of a paired sv is not the same on {}", primaryBreakendLeft.gene());
                 }
                 reportableDisruptions.add(ImmutableGeneDisruption.builder()
-                        .location(primaryBreakendLeft.chromosome() + primaryBreakendLeft.chrBand())
+                        .location(primaryBreakendLeft.chromosome() + primaryBreakendLeft.chromosomeBand())
                         .gene(primaryBreakendLeft.gene())
-                        .transcriptId(primaryBreakendLeft.transcriptId())
-                        .isCanonical(primaryBreakendLeft.canonical())
+                        .transcriptId(primaryBreakendLeft.transcript())
+                        .isCanonical(primaryBreakendLeft.isCanonical())
                         .type(primaryBreakendLeft.type().toString())
                         .range(rangeField(pairedBreakend))
                         .junctionCopyNumber(primaryBreakendLeft.junctionCopyNumber())
@@ -57,10 +58,10 @@ public final class GeneDisruptionFactory {
                         .build());
             } else {
                 reportableDisruptions.add(ImmutableGeneDisruption.builder()
-                        .location(primaryBreakendLeft.chromosome() + primaryBreakendLeft.chrBand())
+                        .location(primaryBreakendLeft.chromosome() + primaryBreakendLeft.chromosomeBand())
                         .gene(primaryBreakendLeft.gene())
-                        .transcriptId(primaryBreakendLeft.transcriptId())
-                        .isCanonical(primaryBreakendLeft.canonical())
+                        .transcriptId(primaryBreakendLeft.transcript())
+                        .isCanonical(primaryBreakendLeft.isCanonical())
                         .type(primaryBreakendLeft.type().toString())
                         .range(rangeField(pairedBreakend))
                         .junctionCopyNumber(primaryBreakendLeft.junctionCopyNumber())
@@ -91,7 +92,7 @@ public final class GeneDisruptionFactory {
             @NotNull Iterable<LinxBreakend> breakends) {
         Map<SvAndTranscriptKey, List<LinxBreakend>> breakendsPerSvAndTranscript = Maps.newHashMap();
         for (LinxBreakend breakend : breakends) {
-            SvAndTranscriptKey key = new SvAndTranscriptKey(breakend.svId(), breakend.transcriptId());
+            SvAndTranscriptKey key = new SvAndTranscriptKey(breakend.svId(), breakend.transcript());
             List<LinxBreakend> currentBreakends = breakendsPerSvAndTranscript.get(key);
             if (currentBreakends == null) {
                 currentBreakends = Lists.newArrayList();
@@ -162,7 +163,7 @@ public final class GeneDisruptionFactory {
     }
 
     private static boolean isUpstream(@NotNull LinxBreakend breakend) {
-        return breakend.orientation() * breakend.strand() < 0;
+        return breakend.geneOrientation().equals(BREAKEND_ORIENTATION_UPSTREAM);
     }
 
     private static class SvAndTranscriptKey {

--- a/common/src/main/java/com/hartwig/oncoact/orange/OrangeJson.java
+++ b/common/src/main/java/com/hartwig/oncoact/orange/OrangeJson.java
@@ -34,6 +34,7 @@ public final class OrangeJson {
                 .purpleCopyNumberPlot(getPlotPath(orangeBasePath, orange.plots().purpleCopyNumberPlot()))
                 .purpleVariantCopyNumberPlot(getPlotPath(orangeBasePath, orange.plots().purpleVariantCopyNumberPlot()))
                 .purplePurityRangePlot(getPlotPath(orangeBasePath, orange.plots().purplePurityRangePlot()))
+                .purpleKataegisPlot(getPlotPath(orangeBasePath, orange.plots().purpleKataegisPlot()))
                 .build();
         return ImmutableOrangeRecord.builder().from(orange).plots(fixedPlots).build();
     }

--- a/common/src/main/java/com/hartwig/oncoact/orange/OrangeJson.java
+++ b/common/src/main/java/com/hartwig/oncoact/orange/OrangeJson.java
@@ -2,12 +2,8 @@ package com.hartwig.oncoact.orange;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ServiceLoader;
 
-import com.google.gson.GsonBuilder;
-import com.google.gson.TypeAdapterFactory;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangePlots;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.OrangePlots;

--- a/common/src/main/java/com/hartwig/oncoact/protect/EventGenerator.java
+++ b/common/src/main/java/com/hartwig/oncoact/protect/EventGenerator.java
@@ -10,7 +10,6 @@ import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariant;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect;
-import com.hartwig.hmftools.datamodel.purple.Variant;
 import com.hartwig.oncoact.variant.ReportableVariant;
 
 import org.jetbrains.annotations.NotNull;
@@ -36,15 +35,14 @@ public final class EventGenerator {
     }
 
     @NotNull
-    public static String variantEvent(@NotNull Variant variant) {
-        if (variant instanceof ReportableVariant) {
-            return reportableVariant((ReportableVariant) variant);
-        } else if (variant instanceof PurpleVariant) {
-            PurpleTranscriptImpact purpleTranscriptImpact = ((PurpleVariant) variant).canonicalImpact();
+    public static String variantEvent(@NotNull PurpleVariant variant) {
+            PurpleTranscriptImpact purpleTranscriptImpact = variant.canonicalImpact();
             return determineVariantAnnotationClinical(purpleTranscriptImpact);
-        } else {
-            throw new IllegalArgumentException(String.format("Unexpected variant type. Variant was: %s", variant));
-        }
+    }
+
+    @NotNull
+    public static String variantEvent(@NotNull ReportableVariant variant) {
+        return reportableVariant(variant);
     }
 
     @NotNull

--- a/common/src/main/java/com/hartwig/oncoact/purple/QcInterpretation.java
+++ b/common/src/main/java/com/hartwig/oncoact/purple/QcInterpretation.java
@@ -1,0 +1,18 @@
+package com.hartwig.oncoact.purple;
+
+import com.hartwig.hmftools.datamodel.purple.PurpleFit;
+import com.hartwig.hmftools.datamodel.purple.PurpleFittedPurityMethod;
+import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
+
+import org.jetbrains.annotations.NotNull;
+
+public class QcInterpretation {
+    public static boolean containsTumorCells(@NotNull PurpleFit purpleFit) {
+        return purpleFit.fittedPurityMethod() != PurpleFittedPurityMethod.NO_TUMOR
+                && !purpleFit.qc().status().contains(PurpleQCStatus.FAIL_NO_TUMOR);
+    }
+
+    public static boolean hasSufficientQuality(@NotNull PurpleFit purpleFit) {
+        return purpleFit.qc().status().size() == 1 &&  purpleFit.qc().status().contains(PurpleQCStatus.PASS);
+    }
+}

--- a/common/src/main/java/com/hartwig/oncoact/variant/ReportableVariant.java
+++ b/common/src/main/java/com/hartwig/oncoact/variant/ReportableVariant.java
@@ -1,10 +1,10 @@
 package com.hartwig.oncoact.variant;
 
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleGenotypeStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleTranscriptImpact;
-import com.hartwig.hmftools.datamodel.purple.Variant;
+import com.hartwig.hmftools.datamodel.purple.PurpleVariantType;
 
 import org.immutables.value.Value;
 import org.jetbrains.annotations.NotNull;
@@ -12,7 +12,24 @@ import org.jetbrains.annotations.Nullable;
 
 @Value.Immutable
 @Value.Style(passAnnotations = { NotNull.class, Nullable.class })
-public abstract class ReportableVariant implements Variant {
+public abstract class ReportableVariant{
+
+    @NotNull
+    public abstract PurpleVariantType type();
+
+    @NotNull
+    public abstract String gene();
+
+    @NotNull
+    public abstract String chromosome();
+
+    public abstract int position();
+
+    @NotNull
+    public abstract String ref();
+
+    @NotNull
+    public abstract String alt();
 
     @NotNull
     public abstract ReportableVariantSource source();
@@ -69,7 +86,7 @@ public abstract class ReportableVariant implements Variant {
     public abstract String tVAF();
 
     @Nullable
-    public abstract Hotspot hotspot();
+    public abstract HotspotType hotspot();
 
     @Nullable
     public abstract Double clonalLikelihood();

--- a/common/src/main/java/com/hartwig/oncoact/variant/ReportableVariantFactory.java
+++ b/common/src/main/java/com/hartwig/oncoact/variant/ReportableVariantFactory.java
@@ -62,7 +62,7 @@ public final class ReportableVariantFactory {
     public static Set<ReportableVariant> toReportableGermlineVariants(@NotNull Collection<PurpleVariant> germlineVariants,
             @NotNull Collection<PurpleDriver> germlineDrivers, @NotNull ClinicalTranscriptsModel clinicalTranscriptsModel) {
         List<PurpleDriver> germlineMutationDrivers =
-                germlineDrivers.stream().filter(x -> x.driver() == PurpleDriverType.GERMLINE_MUTATION).collect(Collectors.toList());
+                germlineDrivers.stream().filter(x -> x.type() == PurpleDriverType.GERMLINE_MUTATION).collect(Collectors.toList());
 
         //Extract germline only variants
         Collection<PurpleVariant> germlineVariantsOnly =
@@ -90,7 +90,7 @@ public final class ReportableVariantFactory {
     public static Set<ReportableVariant> toReportableSomaticVariants(@NotNull Collection<PurpleVariant> somaticVariants,
             @NotNull Collection<PurpleDriver> somaticDrivers, @NotNull ClinicalTranscriptsModel clinicalTranscriptsModel) {
         List<PurpleDriver> somaticMutationDrivers =
-                somaticDrivers.stream().filter(x -> x.driver() == PurpleDriverType.MUTATION).collect(Collectors.toList());
+                somaticDrivers.stream().filter(x -> x.type() == PurpleDriverType.MUTATION).collect(Collectors.toList());
         return toReportableVariants(somaticVariants, somaticMutationDrivers, ReportableVariantSource.SOMATIC, clinicalTranscriptsModel);
     }
 
@@ -166,7 +166,7 @@ public final class ReportableVariantFactory {
         assert variant.reported();
 
         for (PurpleDriver driver : entries.values()) {
-            if (MUTATION_DRIVER_TYPES.contains(driver.driver()) && !driver.isCanonical()) {
+            if (MUTATION_DRIVER_TYPES.contains(driver.type()) && !driver.isCanonical()) {
                 return entries.get(DriverKey.create(variant.gene(), driver.transcript()));
             }
         }

--- a/common/src/main/java/com/hartwig/oncoact/wildtype/WildTypeFactory.java
+++ b/common/src/main/java/com/hartwig/oncoact/wildtype/WildTypeFactory.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Lists;
 import com.hartwig.oncoact.drivergene.DriverGene;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
 import com.hartwig.oncoact.variant.ReportableVariant;
@@ -32,7 +32,7 @@ public final class WildTypeFactory {
     @NotNull
     public static List<WildTypeGene> determineWildTypeGenes(@NotNull Collection<ReportableVariant> reportableGermlineVariants,
             @NotNull Collection<ReportableVariant> reportableSomaticVariants, @NotNull Collection<PurpleGainLoss> reportableSomaticGainsLosses,
-            @NotNull Collection<LinxFusion> reportableFusions, @NotNull Collection<HomozygousDisruption> homozygousDisruptions,
+            @NotNull Collection<LinxFusion> reportableFusions, @NotNull Collection<LinxHomozygousDisruption> homozygousDisruptions,
             @NotNull Collection<LinxBreakend> reportableBreakends, @NotNull Collection<DriverGene> driverGenes) {
         List<WildTypeGene> wildTypeGenes = Lists.newArrayList();
 
@@ -66,7 +66,7 @@ public final class WildTypeFactory {
             }
 
             boolean hasHomozygousDisruption = false;
-            for (HomozygousDisruption homozygousDisruption : homozygousDisruptions) {
+            for (LinxHomozygousDisruption homozygousDisruption : homozygousDisruptions) {
                 if (driverGene.gene().equals(homozygousDisruption.gene())) {
                     hasFusion = true;
                 }

--- a/common/src/main/java/com/hartwig/oncoact/wildtype/WildTypeFactory.java
+++ b/common/src/main/java/com/hartwig/oncoact/wildtype/WildTypeFactory.java
@@ -2,15 +2,14 @@ package com.hartwig.oncoact.wildtype;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import com.google.common.collect.Lists;
-import com.hartwig.oncoact.drivergene.DriverGene;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
+import com.hartwig.oncoact.drivergene.DriverGene;
 import com.hartwig.oncoact.variant.ReportableVariant;
 
 import org.jetbrains.annotations.NotNull;

--- a/common/src/test/java/com/hartwig/oncoact/disruption/GeneDisruptionFactoryTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/disruption/GeneDisruptionFactoryTest.java
@@ -13,6 +13,7 @@ import com.hartwig.hmftools.datamodel.linx.LinxBreakendType;
 import com.hartwig.hmftools.datamodel.linx.LinxSvAnnotation;
 import com.hartwig.oncoact.orange.linx.TestLinxFactory;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 public class GeneDisruptionFactoryTest {
@@ -72,5 +73,20 @@ public class GeneDisruptionFactoryTest {
         List<GeneDisruption> disruptions = GeneDisruptionFactory.convert(pairedDisruptions, Lists.newArrayList());
 
         assertEquals(2, disruptions.size());
+    }
+
+    @Test
+    public void canDetermineDisruptionOrientation() {
+        ImmutableLinxBreakend.Builder pairedBreakendBuilder = TestLinxFactory.breakendBuilder().svId(1);
+        ImmutableLinxBreakend intactUpstream = pairedBreakendBuilder
+                .exonUp(2)
+                .exonDown(2)
+                .geneOrientation("Upstream")
+                .build();
+
+        assertEquals("Exon 2 Downstream", GeneDisruptionFactory.rangeField(Pair.of(intactUpstream, null)));
+
+        ImmutableLinxBreakend intactDownstream = intactUpstream.withGeneOrientation("Downstream");
+        assertEquals("Exon 2 Upstream", GeneDisruptionFactory.rangeField(Pair.of(intactDownstream, null)));
     }
 }

--- a/common/src/test/java/com/hartwig/oncoact/disruption/GeneDisruptionFactoryTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/disruption/GeneDisruptionFactoryTest.java
@@ -35,9 +35,9 @@ public class GeneDisruptionFactoryTest {
         ImmutableLinxBreakend.Builder pairedBreakendBuilder = TestLinxFactory.breakendBuilder()
                 .svId(1)
                 .gene("ROPN1B")
-                .transcriptId("ENST1")
+                .transcript("ENST1")
                 .chromosome("3")
-                .chrBand("p12")
+                .chromosomeBand("p12")
                 .type(LinxBreakendType.INV)
                 .junctionCopyNumber(1.12);
         List<LinxBreakend> pairedBreakends =
@@ -65,9 +65,9 @@ public class GeneDisruptionFactoryTest {
     @Test
     public void doesNotPairBreakendsOnDifferentTranscripts() {
         ImmutableLinxBreakend.Builder pairedBreakendBuilder = TestLinxFactory.breakendBuilder().svId(1);
-        List<LinxBreakend> pairedDisruptions = Lists.newArrayList(pairedBreakendBuilder.transcriptId("ENST 1").svId(1).build(),
-                pairedBreakendBuilder.transcriptId("ENST 2").svId(1).build(),
-                pairedBreakendBuilder.transcriptId("ENST 2").svId(1).build());
+        List<LinxBreakend> pairedDisruptions = Lists.newArrayList(pairedBreakendBuilder.transcript("ENST 1").svId(1).build(),
+                pairedBreakendBuilder.transcript("ENST 2").svId(1).build(),
+                pairedBreakendBuilder.transcript("ENST 2").svId(1).build());
 
         List<GeneDisruption> disruptions = GeneDisruptionFactory.convert(pairedDisruptions, Lists.newArrayList());
 

--- a/common/src/test/java/com/hartwig/oncoact/orange/TestOrangeFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/orange/TestOrangeFactory.java
@@ -28,7 +28,7 @@ import com.hartwig.hmftools.datamodel.orange.OrangeRefGenomeVersion;
 import com.hartwig.hmftools.datamodel.orange.OrangeSample;
 import com.hartwig.hmftools.datamodel.peach.PeachGenotype;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleRecord;
 import com.hartwig.hmftools.datamodel.purple.PurpleCharacteristics;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
@@ -41,11 +41,11 @@ import com.hartwig.hmftools.datamodel.purple.PurpleRecord;
 import com.hartwig.hmftools.datamodel.purple.PurpleTumorMutationalStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariant;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
 import com.hartwig.hmftools.datamodel.virus.ImmutableVirusInterpreterData;
 import com.hartwig.hmftools.datamodel.virus.VirusBreakendQCStatus;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.oncoact.orange.chord.TestChordFactory;
 import com.hartwig.oncoact.orange.cuppa.TestCuppaFactory;
@@ -70,7 +70,7 @@ public final class TestOrangeFactory {
         return ImmutableOrangeRecord.builder()
                 .sampleId("TEST")
                 .tumorSample(createMinimalOrangeSample())
-                .experimentDate(LocalDate.of(2022, 1, 20))
+                .samplingDate(LocalDate.of(2022, 1, 20))
                 .refGenomeVersion(OrangeRefGenomeVersion.V37)
                 .purple(createMinimalTestPurpleRecord())
                 .linx(ImmutableLinxRecord.builder().build())
@@ -157,13 +157,13 @@ public final class TestOrangeFactory {
                 .gene("BRAF")
                 .adjustedCopyNumber(6.0)
                 .variantCopyNumber(4.1)
-                .hotspot(Hotspot.HOTSPOT)
+                .hotspot(HotspotType.HOTSPOT)
                 .subclonalLikelihood(0.02)
                 .biallelic(false)
                 .canonicalImpact(TestPurpleFactory.transcriptImpactBuilder()
                         .hgvsCodingImpact("c.something")
                         .hgvsProteinImpact("p.Val600Glu")
-                        .spliceRegion(false)
+                        .inSpliceRegion(false)
                         .addEffects(PurpleVariantEffect.MISSENSE)
                         .codingEffect(PurpleCodingEffect.MISSENSE)
                         .build())
@@ -174,13 +174,13 @@ public final class TestOrangeFactory {
                 .gene("KRAS")
                 .adjustedCopyNumber(6.0)
                 .variantCopyNumber(4.1)
-                .hotspot(Hotspot.HOTSPOT)
+                .hotspot(HotspotType.HOTSPOT)
                 .subclonalLikelihood(0.02)
                 .biallelic(false)
                 .canonicalImpact(TestPurpleFactory.transcriptImpactBuilder()
                         .hgvsCodingImpact("c.something")
                         .hgvsProteinImpact("p.Val600Glu")
-                        .spliceRegion(false)
+                        .inSpliceRegion(false)
                         .addEffects(PurpleVariantEffect.MISSENSE)
                         .codingEffect(PurpleCodingEffect.MISSENSE)
                         .build())
@@ -216,27 +216,27 @@ public final class TestOrangeFactory {
                 .characteristics(createTestPurpleCharacteristics())
                 .addSomaticDrivers(TestPurpleFactory.driverBuilder()
                         .gene(somaticVariant.gene())
-                        .driver(PurpleDriverType.MUTATION)
+                        .type(PurpleDriverType.MUTATION)
                         .driverLikelihood(1D)
                         .build())
                 .addSomaticDrivers(TestPurpleFactory.driverBuilder()
                         .gene(germlineVariant.gene())
-                        .driver(PurpleDriverType.MUTATION)
+                        .type(PurpleDriverType.MUTATION)
                         .driverLikelihood(1D)
                         .build())
                 .addSomaticDrivers(TestPurpleFactory.driverBuilder()
                         .gene(somaticGain.gene())
-                        .driver(PurpleDriverType.AMP)
+                        .type(PurpleDriverType.AMP)
                         .driverLikelihood(1D)
                         .build())
                 .addSomaticDrivers(TestPurpleFactory.driverBuilder()
                         .gene(somaticLoss.gene())
-                        .driver(PurpleDriverType.DEL)
+                        .type(PurpleDriverType.DEL)
                         .driverLikelihood(1D)
                         .build())
                 .addSomaticDrivers(TestPurpleFactory.driverBuilder()
                         .gene(germlineLoss.gene())
-                        .driver(PurpleDriverType.DEL)
+                        .type(PurpleDriverType.DEL)
                         .driverLikelihood(1D)
                         .build())
                 .addAllSomaticVariants(somaticVariant)
@@ -253,7 +253,7 @@ public final class TestOrangeFactory {
 
     @NotNull
     private static PurpleFit createTestPurpleFit() {
-        return TestPurpleFactory.fitBuilder().hasSufficientQuality(true).containsTumorCells(false).purity(0.12).ploidy(3.1).build();
+        return TestPurpleFactory.fitBuilder().purity(0.12).ploidy(3.1).build();
     }
 
     @NotNull
@@ -271,7 +271,7 @@ public final class TestOrangeFactory {
     @NotNull
     private static LinxRecord createTestLinxRecord() {
         LinxBreakend breakend1 = TestLinxFactory.breakendBuilder()
-                .reportedDisruption(true)
+                .reported(true)
                 .svId(1)
                 .gene("RB1")
                 .type(LinxBreakendType.DEL)
@@ -280,7 +280,7 @@ public final class TestOrangeFactory {
                 .build();
 
         LinxBreakend breakend2 = TestLinxFactory.breakendBuilder()
-                .reportedDisruption(true)
+                .reported(true)
                 .svId(1)
                 .gene("PTEN")
                 .type(LinxBreakendType.DEL)
@@ -295,7 +295,7 @@ public final class TestOrangeFactory {
                 .fusedExonUp(2)
                 .geneEnd("ALK")
                 .fusedExonDown(4)
-                .likelihood(FusionLikelihoodType.HIGH)
+                .driverLikelihood(FusionLikelihoodType.HIGH)
                 .build();
 
         return ImmutableLinxRecord.builder()
@@ -337,13 +337,13 @@ public final class TestOrangeFactory {
 
     @NotNull
     private static VirusInterpreterData createTestVirusInterpreterRecord() {
-        AnnotatedVirus virus = TestVirusInterpreterFactory.builder()
+        VirusInterpreterEntry virus = TestVirusInterpreterFactory.builder()
                 .reported(true)
                 .name("Human papillomavirus type 16")
                 .qcStatus(VirusBreakendQCStatus.NO_ABNORMALITIES)
                 .interpretation(VirusInterpretation.HPV)
                 .integrations(3)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .meanCoverage(0)
                 .build();
 

--- a/common/src/test/java/com/hartwig/oncoact/orange/TestOrangeFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/orange/TestOrangeFactory.java
@@ -8,6 +8,7 @@ import com.hartwig.hmftools.datamodel.chord.ChordRecord;
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
 import com.hartwig.hmftools.datamodel.cuppa.CuppaData;
 import com.hartwig.hmftools.datamodel.cuppa.ImmutableCuppaData;
+import com.hartwig.hmftools.datamodel.cuppa.ImmutableCuppaPrediction;
 import com.hartwig.hmftools.datamodel.flagstat.ImmutableFlagstat;
 import com.hartwig.hmftools.datamodel.hla.ImmutableLilacRecord;
 import com.hartwig.hmftools.datamodel.hla.LilacRecord;
@@ -19,6 +20,7 @@ import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
 import com.hartwig.hmftools.datamodel.linx.LinxRecord;
 import com.hartwig.hmftools.datamodel.metrics.ImmutableWGSMetrics;
+import com.hartwig.hmftools.datamodel.orange.ExperimentType;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangePlots;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeSample;
@@ -69,8 +71,9 @@ public final class TestOrangeFactory {
     public static OrangeRecord createMinimalTestOrangeRecord() {
         return ImmutableOrangeRecord.builder()
                 .sampleId("TEST")
-                .tumorSample(createMinimalOrangeSample())
                 .samplingDate(LocalDate.of(2022, 1, 20))
+                .experimentType(ExperimentType.WHOLE_GENOME)
+                .tumorSample(createMinimalOrangeSample())
                 .refGenomeVersion(OrangeRefGenomeVersion.V37)
                 .purple(createMinimalTestPurpleRecord())
                 .linx(ImmutableLinxRecord.builder().build())
@@ -133,6 +136,7 @@ public final class TestOrangeFactory {
                 .purpleVariantCopyNumberPlot(Strings.EMPTY)
                 .purplePurityRangePlot(Strings.EMPTY)
                 .purpleFinalCircosPlot(EMPTY_CIRCOS_PLOT)
+                .purpleKataegisPlot(Strings.EMPTY)
                 .build();
     }
 
@@ -326,8 +330,11 @@ public final class TestOrangeFactory {
 
     @NotNull
     private static CuppaData createTestCuppaRecord() {
+        ImmutableCuppaPrediction prediction =
+                TestCuppaFactory.builder().cancerType("Melanoma").likelihood(0.996).build();
         return ImmutableCuppaData.builder()
-                .addPredictions(TestCuppaFactory.builder().cancerType("Melanoma").likelihood(0.996).build())
+                .addPredictions(prediction)
+                .bestPrediction(prediction)
                 .simpleDups32To200B(0)
                 .maxComplexSize(0)
                 .telomericSGLs(0)

--- a/common/src/test/java/com/hartwig/oncoact/orange/linx/TestLinxFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/orange/linx/TestLinxFactory.java
@@ -4,9 +4,9 @@ import com.hartwig.hmftools.datamodel.gene.TranscriptCodingType;
 import com.hartwig.hmftools.datamodel.gene.TranscriptRegionType;
 import com.hartwig.hmftools.datamodel.linx.FusionLikelihoodType;
 import com.hartwig.hmftools.datamodel.linx.FusionPhasedType;
-import com.hartwig.hmftools.datamodel.linx.ImmutableHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxFusion;
+import com.hartwig.hmftools.datamodel.linx.ImmutableLinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxSvAnnotation;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakendType;
@@ -45,8 +45,8 @@ public final class TestLinxFactory {
     }
 
     @NotNull
-    public static ImmutableHomozygousDisruption.Builder homozygousDisruptionBuilder() {
-        return ImmutableHomozygousDisruption.builder()
+    public static ImmutableLinxHomozygousDisruption.Builder homozygousDisruptionBuilder() {
+        return ImmutableLinxHomozygousDisruption.builder()
                 .chromosome(Strings.EMPTY)
                 .chromosomeBand(Strings.EMPTY)
                 .gene(Strings.EMPTY)
@@ -57,15 +57,15 @@ public final class TestLinxFactory {
     @NotNull
     public static ImmutableLinxBreakend.Builder breakendBuilder() {
         return ImmutableLinxBreakend.builder()
-                .reportedDisruption(true)
+                .reported(true)
                 .disruptive(false)
                 .id(0)
                 .svId(0)
                 .gene(Strings.EMPTY)
                 .chromosome(Strings.EMPTY)
-                .chrBand(Strings.EMPTY)
-                .transcriptId(Strings.EMPTY)
-                .canonical(false)
+                .chromosomeBand(Strings.EMPTY)
+                .transcript(Strings.EMPTY)
+                .isCanonical(false)
                 .type(LinxBreakendType.BND)
                 .junctionCopyNumber(0D)
                 .undisruptedCopyNumber(0D)
@@ -74,7 +74,6 @@ public final class TestLinxFactory {
                 .exonDown(0)
                 .geneOrientation(Strings.EMPTY)
                 .orientation(0)
-                .strand(0)
                 .regionType(TranscriptRegionType.INTRONIC)
                 .codingType(TranscriptCodingType.NON_CODING);
     }
@@ -84,7 +83,6 @@ public final class TestLinxFactory {
         return ImmutableLinxFusion.builder()
                 .reported(true)
                 .reportedType(LinxFusionType.NONE)
-                .name(Strings.EMPTY)
                 .geneStart(Strings.EMPTY)
                 .geneTranscriptStart(Strings.EMPTY)
                 .geneContextStart(Strings.EMPTY)
@@ -93,7 +91,7 @@ public final class TestLinxFactory {
                 .geneTranscriptEnd(Strings.EMPTY)
                 .geneContextEnd(Strings.EMPTY)
                 .fusedExonDown(0)
-                .likelihood(FusionLikelihoodType.LOW)
+                .driverLikelihood(FusionLikelihoodType.LOW)
                 .phased(FusionPhasedType.OUT_OF_FRAME)
                 .junctionCopyNumber(0D)
                 .chainLinks(0)

--- a/common/src/test/java/com/hartwig/oncoact/orange/purple/TestPurpleFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/orange/purple/TestPurpleFactory.java
@@ -3,7 +3,7 @@ package com.hartwig.oncoact.orange.purple;
 import java.util.List;
 
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleAllelicDepth;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleCharacteristics;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleCopyNumber;
@@ -36,8 +36,6 @@ public final class TestPurpleFactory {
     @NotNull
     public static ImmutablePurpleFit.Builder fitBuilder() {
         return ImmutablePurpleFit.builder()
-                .hasSufficientQuality(false)
-                .containsTumorCells(false)
                 .purity(0)
                 .minPurity(0)
                 .maxPurity(0)
@@ -77,7 +75,7 @@ public final class TestPurpleFactory {
         return ImmutablePurpleDriver.builder()
                 .gene(Strings.EMPTY)
                 .transcript(Strings.EMPTY)
-                .driver(PurpleDriverType.MUTATION)
+                .type(PurpleDriverType.MUTATION)
                 .likelihoodMethod(PurpleLikelihoodMethod.AMP)
                 .isCanonical(true)
                 .driverLikelihood(0D);
@@ -96,7 +94,7 @@ public final class TestPurpleFactory {
                 .adjustedCopyNumber(0D)
                 .minorAlleleCopyNumber(0D)
                 .variantCopyNumber(0D)
-                .hotspot(Hotspot.NON_HOTSPOT)
+                .hotspot(HotspotType.NON_HOTSPOT)
                 .tumorDepth(depthBuilder().build())
                 .subclonalLikelihood(0D)
                 .biallelic(false)
@@ -113,7 +111,7 @@ public final class TestPurpleFactory {
                 .transcript(Strings.EMPTY)
                 .hgvsCodingImpact(Strings.EMPTY)
                 .hgvsProteinImpact(Strings.EMPTY)
-                .spliceRegion(false)
+                .inSpliceRegion(false)
                 .codingEffect(PurpleCodingEffect.UNDEFINED);
     }
 
@@ -127,7 +125,7 @@ public final class TestPurpleFactory {
         return ImmutablePurpleGeneCopyNumber.builder()
                 .chromosome(Strings.EMPTY)
                 .chromosomeBand(Strings.EMPTY)
-                .geneName(Strings.EMPTY)
+                .gene(Strings.EMPTY)
                 .minCopyNumber(0D)
                 .minMinorAlleleCopyNumber(0D);
     }

--- a/common/src/test/java/com/hartwig/oncoact/orange/virus/TestVirusInterpreterFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/orange/virus/TestVirusInterpreterFactory.java
@@ -1,6 +1,6 @@
 package com.hartwig.oncoact.orange.virus;
 
-import com.hartwig.hmftools.datamodel.virus.ImmutableAnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.ImmutableVirusInterpreterEntry;
 import com.hartwig.hmftools.datamodel.virus.VirusBreakendQCStatus;
 import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 
@@ -13,13 +13,13 @@ public final class TestVirusInterpreterFactory {
     }
 
     @NotNull
-    public static ImmutableAnnotatedVirus.Builder builder() {
-        return ImmutableAnnotatedVirus.builder()
+    public static ImmutableVirusInterpreterEntry.Builder builder() {
+        return ImmutableVirusInterpreterEntry.builder()
                 .reported(true)
                 .name(Strings.EMPTY)
                 .qcStatus(VirusBreakendQCStatus.NO_ABNORMALITIES)
                 .integrations(0)
-                .virusDriverLikelihoodType(VirusLikelihoodType.LOW)
+                .driverLikelihood(VirusLikelihoodType.LOW)
                 .meanCoverage(0)
                 .percentageCovered(0D);
     }

--- a/common/src/test/java/com/hartwig/oncoact/protect/EventGeneratorTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/protect/EventGeneratorTest.java
@@ -9,8 +9,8 @@ import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleTranscriptImpact;
+import com.hartwig.hmftools.datamodel.purple.PurpleVariant;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect;
-import com.hartwig.hmftools.datamodel.purple.Variant;
 import com.hartwig.oncoact.orange.linx.TestLinxFactory;
 import com.hartwig.oncoact.orange.purple.TestPurpleFactory;
 import com.hartwig.oncoact.variant.ReportableVariant;
@@ -42,7 +42,7 @@ public class EventGeneratorTest {
                 .transcript(transcript)
                 .hgvsCodingImpact(hgvsCodingImpact)
                 .hgvsProteinImpact(hgvsProteinImpact)
-                .spliceRegion(false)
+                .inSpliceRegion(false)
                 .codingEffect(PurpleCodingEffect.UNDEFINED)
                 .build();
     }
@@ -91,18 +91,18 @@ public class EventGeneratorTest {
 
     @Test
     public void canGenerateEventForVariant() {
-        Variant base = TestPurpleFactory.variantBuilder()
+        PurpleVariant base = TestPurpleFactory.variantBuilder()
                 .canonicalImpact(TestPurpleFactory.transcriptImpactBuilder().addEffects(PurpleVariantEffect.MISSENSE).build())
                 .build();
         assertEquals("missense", EventGenerator.variantEvent(base));
 
-        Variant coding = TestPurpleFactory.variantBuilder()
+        PurpleVariant coding = TestPurpleFactory.variantBuilder()
                 .from(base)
                 .canonicalImpact(TestPurpleFactory.transcriptImpactBuilder().hgvsCodingImpact("coding impact").build())
                 .build();
         assertEquals("coding impact", EventGenerator.variantEvent(coding));
 
-        Variant protein = TestPurpleFactory.variantBuilder()
+        PurpleVariant protein = TestPurpleFactory.variantBuilder()
                 .from(base)
                 .canonicalImpact(TestPurpleFactory.transcriptImpactBuilder().hgvsProteinImpact("protein impact").build())
                 .build();

--- a/common/src/test/java/com/hartwig/oncoact/variant/DriverMapTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/variant/DriverMapTest.java
@@ -35,6 +35,6 @@ public class DriverMapTest {
 
     @NotNull
     private static ImmutablePurpleDriver.Builder mutationBuilder() {
-        return TestPurpleFactory.driverBuilder().driver(PurpleDriverType.MUTATION);
+        return TestPurpleFactory.driverBuilder().type(PurpleDriverType.MUTATION);
     }
 }

--- a/common/src/test/java/com/hartwig/oncoact/variant/ReportableVariantFactoryTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/variant/ReportableVariantFactoryTest.java
@@ -40,7 +40,7 @@ public class ReportableVariantFactoryTest {
                 .gene("gene 1")
                 .transcript("transcript 1")
                 .driverLikelihood(0.6)
-                .driver(PurpleDriverType.MUTATION)
+                .type(PurpleDriverType.MUTATION)
                 .build();
 
         Set<ReportableVariant> reportable = ReportableVariantFactory.toReportableSomaticVariants(variants,
@@ -64,10 +64,10 @@ public class ReportableVariantFactoryTest {
                 .gene("gene")
                 .driverLikelihood(0.6)
                 .transcript("transcript 1")
-                .driver(PurpleDriverType.GERMLINE_MUTATION)
+                .type(PurpleDriverType.GERMLINE_MUTATION)
                 .build();
         PurpleDriver driver2 =
-                TestPurpleFactory.driverBuilder().from(driver1).driverLikelihood(1D).driver(PurpleDriverType.GERMLINE_DELETION).build();
+                TestPurpleFactory.driverBuilder().from(driver1).driverLikelihood(1D).type(PurpleDriverType.GERMLINE_DELETION).build();
         Set<PurpleDriver> drivers = Sets.newHashSet(driver1, driver2);
 
         Set<ReportableVariant> reportable = ReportableVariantFactory.toReportableGermlineVariants(Sets.newHashSet(variant1),
@@ -90,10 +90,10 @@ public class ReportableVariantFactoryTest {
                 .gene("gene")
                 .driverLikelihood(0.6)
                 .transcript("transcript 1")
-                .driver(PurpleDriverType.GERMLINE_MUTATION)
+                .type(PurpleDriverType.GERMLINE_MUTATION)
                 .build();
         PurpleDriver driver2 =
-                TestPurpleFactory.driverBuilder().from(driver1).driverLikelihood(1D).driver(PurpleDriverType.GERMLINE_DELETION).build();
+                TestPurpleFactory.driverBuilder().from(driver1).driverLikelihood(1D).type(PurpleDriverType.GERMLINE_DELETION).build();
         Set<PurpleDriver> drivers = Sets.newHashSet(driver1, driver2);
 
         Set<ReportableVariant> reportable = ReportableVariantFactory.toReportableGermlineVariants(Sets.newHashSet(variant1),

--- a/common/src/test/java/com/hartwig/oncoact/variant/TestReportableVariantFactory.java
+++ b/common/src/test/java/com/hartwig/oncoact/variant/TestReportableVariantFactory.java
@@ -1,6 +1,6 @@
 package com.hartwig.oncoact.variant;
 
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleGenotypeStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantType;
@@ -37,7 +37,7 @@ public final class TestReportableVariantFactory {
                 .alleleCopyNumber(0D)
                 .minorAlleleCopyNumber(0D)
                 .tVAF(Strings.EMPTY)
-                .hotspot(Hotspot.HOTSPOT)
+                .hotspot(HotspotType.HOTSPOT)
                 .clonalLikelihood(0D)
                 .driverLikelihood(0D)
                 .biallelic(false);

--- a/common/src/test/java/com/hartwig/oncoact/wildtype/WildTypeFactoryTest.java
+++ b/common/src/test/java/com/hartwig/oncoact/wildtype/WildTypeFactoryTest.java
@@ -7,11 +7,11 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.oncoact.drivergene.DriverGene;
 import com.hartwig.oncoact.drivergene.TestDriverGeneFactory;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.oncoact.orange.linx.TestLinxFactory;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
@@ -35,7 +35,7 @@ public class WildTypeFactoryTest {
 
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         Set<LinxFusion> reportableFusions = Sets.newHashSet();
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("BRCA2"));
 
@@ -58,7 +58,7 @@ public class WildTypeFactoryTest {
         Set<ReportableVariant> reportableSomaticVariants = Sets.newHashSet();
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         Set<LinxFusion> reportableFusions = Sets.newHashSet();
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
 
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("BRCA1"));
@@ -83,7 +83,7 @@ public class WildTypeFactoryTest {
                 TestPurpleFactory.gainLossBuilder().gene("APC").interpretation(CopyNumberInterpretation.FULL_LOSS).build();
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet(reportableAmp, reportableDel);
         Set<LinxFusion> reportableFusions = Sets.newHashSet();
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
 
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("APC", "KRAS"));
@@ -105,7 +105,7 @@ public class WildTypeFactoryTest {
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         LinxFusion reportedFusionMatch = createFusion("BAG4", "EGFR");
         Set<LinxFusion> reportableFusions = Sets.newHashSet(reportedFusionMatch);
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
 
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("BAG4"));
@@ -127,7 +127,7 @@ public class WildTypeFactoryTest {
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         LinxFusion reportedFusionMatch = createFusion("EGFR", "BAG4");
         Set<LinxFusion> reportableFusions = Sets.newHashSet(reportedFusionMatch);
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
 
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("BAG4"));
@@ -148,8 +148,8 @@ public class WildTypeFactoryTest {
         Set<ReportableVariant> reportableSomaticVariants = Sets.newHashSet();
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         Set<LinxFusion> reportableFusions = Sets.newHashSet();
-        HomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
+        LinxHomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet();
 
         List<DriverGene> driverGenes = createDriverList(Lists.newArrayList("NRAS"));
@@ -170,7 +170,7 @@ public class WildTypeFactoryTest {
         Set<ReportableVariant> reportableSomaticVariants = Sets.newHashSet();
         Set<PurpleGainLoss> reportableSomaticGainsLosses = Sets.newHashSet();
         Set<LinxFusion> reportableFusions = Sets.newHashSet();
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet();
 
         LinxBreakend breakend = createBreakend("MYC");
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet(breakend);
@@ -206,8 +206,8 @@ public class WildTypeFactoryTest {
         LinxFusion reportedFusionMatch = createFusion("BAG4", "FGFR1");
         Set<LinxFusion> reportableFusions = Sets.newHashSet(reportedFusionMatch);
 
-        HomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
+        LinxHomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
 
         LinxBreakend breakend = createBreakend("MYC");
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet(breakend);
@@ -244,8 +244,8 @@ public class WildTypeFactoryTest {
         LinxFusion reportedFusionMatch = createFusion("BAG4", "FGFR1");
         Set<LinxFusion> reportableFusions = Sets.newHashSet(reportedFusionMatch);
 
-        HomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
+        LinxHomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
 
         LinxBreakend breakend = createBreakend("MYC");
         Set<LinxBreakend> reportableBreakends = Sets.newHashSet(breakend);
@@ -288,7 +288,7 @@ public class WildTypeFactoryTest {
     }
 
     @NotNull
-    private static HomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
+    private static LinxHomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
         return TestLinxFactory.homozygousDisruptionBuilder().gene(gene).build();
     }
 

--- a/common/src/test/resources/orange/minimally.populated.orange.json
+++ b/common/src/test/resources/orange/minimally.populated.orange.json
@@ -1,6 +1,7 @@
 {
   "sampleId": "TEST",
-  "experimentDate": {
+  "experimentType": "WHOLE_GENOME",
+  "samplingDate": {
     "year": 2022,
     "month": 1,
     "day": 20
@@ -50,8 +51,6 @@
         "amberMeanDepth": 111
       },
       "fittedPurityMethod": "NORMAL",
-      "hasSufficientQuality": true,
-      "containsTumorCells": false,
       "purity": 0.12,
       "minPurity": 0.97,
       "maxPurity": 1.0,
@@ -73,7 +72,7 @@
       {
         "gene": "SF3B1",
         "transcript": "ENST00000335508",
-        "driver": "MUTATION",
+        "type": "MUTATION",
         "driverLikelihood": 0.2,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -81,7 +80,7 @@
       {
         "gene": "SMAD4",
         "transcript": "ENST00000342988",
-        "driver": "DEL",
+        "type": "DEL",
         "driverLikelihood": 1.0,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -91,7 +90,7 @@
       {
         "gene": "BRCA1",
         "transcript": "ENST00000471181",
-        "driver": "GERMLINE_MUTATION",
+        "type": "GERMLINE_MUTATION",
         "driverLikelihood": 0.8,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -114,11 +113,12 @@
           "hgvsProteinImpact": "p.Pro718Leu",
           "affectedCodon": 2153,
           "affectedExon": 12,
-          "spliceRegion": false,
+          "inSpliceRegion": false,
           "effects": [
             "MISSENSE"
           ],
-          "codingEffect": "MISSENSE"
+          "codingEffect": "MISSENSE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "NON_HOTSPOT",
@@ -153,11 +153,12 @@
           "hgvsProteinImpact": "p.Pro718Leu",
           "affectedCodon": 2153,
           "affectedExon": 12,
-          "spliceRegion": false,
+          "inSpliceRegion": false,
           "effects": [
             "MISSENSE"
           ],
-          "codingEffect": "MISSENSE"
+          "codingEffect": "MISSENSE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "NON_HOTSPOT",
@@ -192,12 +193,13 @@
           "hgvsProteinImpact": "p.?",
           "affectedCodon": null,
           "affectedExon": null,
-          "spliceRegion": true,
+          "inSpliceRegion": true,
           "effects": [
             "SPLICE_DONOR",
             "INTRONIC"
           ],
-          "codingEffect": "SPLICE"
+          "codingEffect": "SPLICE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "HOTSPOT",
@@ -235,12 +237,13 @@
           "hgvsProteinImpact": "p.?",
           "affectedCodon": null,
           "affectedExon": null,
-          "spliceRegion": true,
+          "inSpliceRegion": true,
           "effects": [
             "SPLICE_DONOR",
             "INTRONIC"
           ],
-          "codingEffect": "SPLICE"
+          "codingEffect": "SPLICE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "HOTSPOT",
@@ -271,10 +274,11 @@
     ],
     "allSomaticGeneCopyNumbers": [
       {
-        "geneName": "gene",
+        "gene": "gene",
         "chromosome": "12",
         "chromosomeBand": "p13",
         "minCopyNumber": 1.2,
+        "maxCopyNumber": 1.2,
         "minMinorAlleleCopyNumber": 0.4
       }
     ],
@@ -286,8 +290,8 @@
         "gene": "SMAD4",
         "transcript": "ENST00000591126",
         "isCanonical": false,
-        "minCopies": 0,
-        "maxCopies": 1
+        "minCopies": 0.1,
+        "maxCopies": 1.2
       }
     ],
     "reportableSomaticGainsLosses": [
@@ -298,17 +302,17 @@
         "gene": "SMAD4",
         "transcript": "ENST00000591126",
         "isCanonical": false,
-        "minCopies": 0,
-        "maxCopies": 1
+        "minCopies": 0.1,
+        "maxCopies": 1.2
       }
     ],
-
     "suspectGeneCopyNumbersWithLOH": [
       {
-        "geneName": "gene",
+        "gene": "gene",
         "chromosome": "12",
         "chromosomeBand": "p13",
         "minCopyNumber": 1.2,
+        "maxCopyNumber": 1.2,
         "minMinorAlleleCopyNumber": 0.4
       }
     ]
@@ -341,7 +345,7 @@
       {
         "reported": true,
         "reportedType": "KNOWN_PAIR",
-        "likelihood": "HIGH",
+        "driverLikelihood": "HIGH",
         "fusedExonUp": 1,
         "fusedExonDown": 2,
         "name": "TMPRSS2-ETV4",
@@ -363,7 +367,7 @@
       {
         "reported": true,
         "reportedType": "KNOWN_PAIR",
-        "likelihood": "HIGH",
+        "driverLikelihood": "HIGH",
         "fusedExonUp": 1,
         "fusedExonDown": 2,
         "name": "TMPRSS2-ETV4",
@@ -383,15 +387,15 @@
     ],
     "allSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -407,15 +411,15 @@
     ],
     "reportableSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -440,15 +444,15 @@
     ],
     "additionalSuspectSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -472,7 +476,7 @@
         "integrations": 1,
         "interpretation": "HPV",
         "reported": true,
-        "virusDriverLikelihoodType": "HIGH",
+        "driverLikelihood": "HIGH",
         "percentageCovered": 0.9,
         "meanCoverage": 0
       },
@@ -482,7 +486,7 @@
         "integrations": 0,
         "interpretation": null,
         "reported": false,
-        "virusDriverLikelihoodType": "LOW",
+        "driverLikelihood": "LOW",
         "percentageCovered": 0.4,
         "meanCoverage": 0
       }
@@ -494,7 +498,7 @@
         "integrations": 1,
         "interpretation": "HPV",
         "reported": true,
-        "virusDriverLikelihoodType": "HIGH",
+        "driverLikelihood": "HIGH",
         "percentageCovered": 0.9,
         "meanCoverage": 0
       }
@@ -519,10 +523,24 @@
     }
   ],
   "cuppa": {
+    "bestPrediction": {
+      "cancerType": "Melanoma",
+      "likelihood": 0.996,
+      "snvPairwiseClassifier": 0.979,
+      "genomicPositionClassifier": 0.990,
+      "featureClassifier": 0.972,
+      "altSjCohortClassifier": null,
+      "expressionPairwiseClassifier": null
+    },
     "predictions": [
       {
         "cancerType": "Melanoma",
-        "likelihood": 0.996
+        "likelihood": 0.996,
+        "snvPairwiseClassifier": 0.979,
+        "genomicPositionClassifier": 0.990,
+        "featureClassifier": 0.972,
+        "altSjCohortClassifier": null,
+        "expressionPairwiseClassifier": null
       }
     ],
     "simpleDups32To200B": 0,
@@ -554,6 +572,7 @@
     "purpleClonalityPlot": "",
     "purpleCopyNumberPlot": "",
     "purpleVariantCopyNumberPlot": "",
-    "purplePurityRangePlot": ""
+    "purplePurityRangePlot": "",
+    "purpleKataegisPlot": ""
   }
 }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/CurationFunctions.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/CurationFunctions.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
-import com.hartwig.hmftools.datamodel.linx.ImmutableHomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.ImmutableLinxHomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.oncoact.disruption.GeneDisruption;
@@ -144,16 +144,16 @@ public final class CurationFunctions {
 
     @NotNull
     @VisibleForTesting
-    static List<HomozygousDisruption> curateHomozygousDisruptions(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
-        List<HomozygousDisruption> curateHomozygousDisruptions = Lists.newArrayList();
-        for (HomozygousDisruption homozygousDisruption : homozygousDisruptions) {
+    static List<LinxHomozygousDisruption> curateHomozygousDisruptions(@NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
+        List<LinxHomozygousDisruption> curateHomozygousDisruptions = Lists.newArrayList();
+        for (LinxHomozygousDisruption homozygousDisruption : homozygousDisruptions) {
             if (homozygousDisruption.gene().equals(GENE_CDKN2A) && homozygousDisruption.isCanonical()) {
-                curateHomozygousDisruptions.add(ImmutableHomozygousDisruption.builder()
+                curateHomozygousDisruptions.add(ImmutableLinxHomozygousDisruption.builder()
                         .from(homozygousDisruption)
                         .gene(GENE_CDKN2A_CANONICAL)
                         .build());
             } else if (homozygousDisruption.gene().equals(GENE_CDKN2A) && !homozygousDisruption.isCanonical()) {
-                curateHomozygousDisruptions.add(ImmutableHomozygousDisruption.builder()
+                curateHomozygousDisruptions.add(ImmutableLinxHomozygousDisruption.builder()
                         .from(homozygousDisruption)
                         .gene(GENE_CDKN2A_NON_CANONICAL)
                         .build());

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/GenomicAnalysis.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/GenomicAnalysis.java
@@ -5,13 +5,13 @@ import java.util.Map;
 import java.util.Set;
 
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleTumorMutationalStatus;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
 import com.hartwig.oncoact.disruption.GeneDisruption;
 import com.hartwig.oncoact.protect.ProtectEvidence;
@@ -80,10 +80,10 @@ public abstract class GenomicAnalysis {
     public abstract List<GeneDisruption> geneDisruptions();
 
     @NotNull
-    public abstract List<HomozygousDisruption> homozygousDisruptions();
+    public abstract List<LinxHomozygousDisruption> homozygousDisruptions();
 
     @NotNull
-    public abstract List<AnnotatedVirus> reportableViruses();
+    public abstract List<VirusInterpreterEntry> reportableViruses();
 
     @NotNull
     public abstract List<InterpretPurpleGeneCopyNumbers> suspectGeneCopyNumbersWithLOH();

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/GenomicAnalyzer.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/GenomicAnalyzer.java
@@ -1,5 +1,8 @@
 package com.hartwig.oncoact.patientreporter.algo;
 
+import static com.hartwig.oncoact.purple.QcInterpretation.containsTumorCells;
+import static com.hartwig.oncoact.purple.QcInterpretation.hasSufficientQuality;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,9 +11,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxSvAnnotation;
 import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.OrangeRefGenomeVersion;
@@ -88,9 +91,9 @@ public class GenomicAnalyzer {
         List<LinxFusion> geneFusions = orange.linx().reportableSomaticFusions();
 
         // homozygous disruptions
-        List<HomozygousDisruption> somaticHomozygousDisruptions = orange.linx().somaticHomozygousDisruptions();
-        List<HomozygousDisruption> germlineHomozygousDisruptions = orange.linx().germlineHomozygousDisruptions();
-        List<HomozygousDisruption> homozygousDisruptions =
+        List<LinxHomozygousDisruption> somaticHomozygousDisruptions = orange.linx().somaticHomozygousDisruptions();
+        List<LinxHomozygousDisruption> germlineHomozygousDisruptions = orange.linx().germlineHomozygousDisruptions();
+        List<LinxHomozygousDisruption> homozygousDisruptions =
                 ListUtil.mergeListsDistinct(somaticHomozygousDisruptions, germlineHomozygousDisruptions);
 
         //disruptions
@@ -124,8 +127,8 @@ public class GenomicAnalyzer {
         return ImmutableGenomicAnalysis.builder()
                 .purpleQCStatus(orange.purple().fit().qc().status())
                 .impliedPurity(orange.purple().fit().purity())
-                .hasReliablePurity(orange.purple().fit().containsTumorCells())
-                .hasReliableQuality(orange.purple().fit().hasSufficientQuality())
+                .hasReliablePurity(containsTumorCells(orange.purple().fit()))
+                .hasReliableQuality(hasSufficientQuality(orange.purple().fit()))
                 .averageTumorPloidy(orange.purple().fit().ploidy())
                 .tumorSpecificEvidence(nonTrialsOnLabel)
                 .clinicalTrials(trialsOnLabel)

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/InterpretPurpleGeneCopyNumbersFactory.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/algo/InterpretPurpleGeneCopyNumbersFactory.java
@@ -1,10 +1,11 @@
 package com.hartwig.oncoact.patientreporter.algo;
 
+import java.util.List;
+
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.datamodel.purple.PurpleGeneCopyNumber;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class InterpretPurpleGeneCopyNumbersFactory {
 
@@ -19,7 +20,7 @@ public class InterpretPurpleGeneCopyNumbersFactory {
             InterpretLOHGenes.add(ImmutableInterpretPurpleGeneCopyNumbers.builder()
                     .chromosome(LOHGene.chromosome())
                     .chromosomeBand(LOHGene.chromosomeBand())
-                    .geneName(LOHGene.geneName())
+                    .geneName(LOHGene.gene())
                     .minCopyNumber(LOHGene.minCopyNumber())
                     .minMinorAlleleCopyNumber(LOHGene.minMinorAlleleCopyNumber())
                     .build());

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/GenomicAlterationsChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/chapters/analysed/GenomicAlterationsChapter.java
@@ -6,12 +6,12 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.peach.PeachGenotype;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
 import com.hartwig.oncoact.disruption.GeneDisruption;
 import com.hartwig.oncoact.hla.HlaAllelesReportingData;
@@ -294,7 +294,7 @@ public class GenomicAlterationsChapter implements ReportChapter {
     }
 
     @NotNull
-    private Table createHomozygousDisruptionsTable(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
+    private Table createHomozygousDisruptionsTable(@NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
         String title = "Tumor observed homozygous disruptions";
         String subtitle = "Complete loss of wild type allele";
         if (homozygousDisruptions.isEmpty()) {
@@ -306,7 +306,7 @@ public class GenomicAlterationsChapter implements ReportChapter {
                         tableUtil.createHeaderCell("Gene") },
                 ReportResources.CONTENT_WIDTH_WIDE);
 
-        for (HomozygousDisruption homozygousDisruption : HomozygousDisruptions.sort(homozygousDisruptions)) {
+        for (LinxHomozygousDisruption homozygousDisruption : HomozygousDisruptions.sort(homozygousDisruptions)) {
             contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.chromosome()));
             contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.chromosomeBand()));
             contentTable.addCell(tableUtil.createContentCell(homozygousDisruption.gene()));
@@ -465,7 +465,7 @@ public class GenomicAlterationsChapter implements ReportChapter {
     }
 
     @NotNull
-    private Table createVirusTable(@NotNull List<AnnotatedVirus> viruses) {
+    private Table createVirusTable(@NotNull List<VirusInterpreterEntry> viruses) {
         String title = "Tumor observed viral insertions";
 
         if (viruses.isEmpty()) {
@@ -478,10 +478,10 @@ public class GenomicAlterationsChapter implements ReportChapter {
                             tableUtil.createHeaderCell("Driver").setTextAlignment(TextAlignment.CENTER) },
                     ReportResources.CONTENT_WIDTH_WIDE);
 
-            for (AnnotatedVirus virus : viruses) {
+            for (VirusInterpreterEntry virus : viruses) {
                 contentTable.addCell(tableUtil.createContentCell(ViralPresence.interpretVirusName(virus.name(),
                         virus.interpretation(),
-                        virus.virusDriverLikelihoodType())));
+                        virus.driverLikelihood())));
                 contentTable.addCell(tableUtil.createContentCell(ViralPresence.integrations(virus)).setTextAlignment(TextAlignment.CENTER));
                 contentTable.addCell(tableUtil.createContentCell(ViralPresence.percentageCovered(virus))
                         .setTextAlignment(TextAlignment.CENTER));

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/GeneFusions.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/GeneFusions.java
@@ -31,14 +31,14 @@ public final class GeneFusions {
     @NotNull
     public static List<LinxFusion> sort(@NotNull List<LinxFusion> fusions) {
         return fusions.stream().sorted((fusion1, fusion2) -> {
-            if (fusion1.likelihood() == fusion2.likelihood()) {
+            if (fusion1.driverLikelihood() == fusion2.driverLikelihood()) {
                 if (fusion1.geneStart().equals(fusion2.geneStart())) {
                     return fusion1.geneEnd().compareTo(fusion2.geneEnd());
                 } else {
                     return fusion1.geneStart().compareTo(fusion2.geneStart());
                 }
             } else {
-                return fusion1.likelihood() == FusionLikelihoodType.HIGH ? -1 : 1;
+                return fusion1.driverLikelihood() == FusionLikelihoodType.HIGH ? -1 : 1;
             }
         }).collect(Collectors.toList());
     }
@@ -123,7 +123,7 @@ public final class GeneFusions {
 
     @NotNull
     public static String likelihood(@NotNull LinxFusion fusion) {
-        switch (fusion.likelihood()) {
+        switch (fusion.driverLikelihood()) {
             case HIGH: {
                 return "High";
             }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/HomozygousDisruptions.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/HomozygousDisruptions.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.oncoact.patientreporter.algo.CurationFunctions;
 
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +16,7 @@ public final class HomozygousDisruptions {
     }
 
     @NotNull
-    public static List<HomozygousDisruption> sort(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
+    public static List<LinxHomozygousDisruption> sort(@NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
         return homozygousDisruptions.stream().sorted((disruption1, disruption2) -> {
             String location1 = GeneUtil.zeroPrefixed(disruption1.chromosome() + disruption1.chromosomeBand());
             String location2 = GeneUtil.zeroPrefixed(disruption2.chromosome() + disruption2.chromosomeBand());
@@ -30,9 +30,9 @@ public final class HomozygousDisruptions {
     }
 
     @NotNull
-    public static Set<String> disruptedGenes(@NotNull List<HomozygousDisruption> homozygousDisruptions) {
+    public static Set<String> disruptedGenes(@NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
         Set<String> genes = Sets.newTreeSet();
-        for (HomozygousDisruption disruption : homozygousDisruptions) {
+        for (LinxHomozygousDisruption disruption : homozygousDisruptions) {
             genes.add(CurationFunctions.curateGeneNamePdf(disruption.gene()));
         }
         return genes;

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/SomaticVariants.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/SomaticVariants.java
@@ -12,9 +12,9 @@ import com.google.api.client.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect;
@@ -159,7 +159,7 @@ public final class SomaticVariants {
     }
 
     @NotNull
-    public static String hotspotString(@Nullable Hotspot hotspot) {
+    public static String hotspotString(@Nullable HotspotType hotspot) {
         if (hotspot == null) {
             return Strings.EMPTY;
         } else {
@@ -229,7 +229,7 @@ public final class SomaticVariants {
 
     @NotNull
     public static Set<String> determineMSIGenes(@NotNull List<ReportableVariant> reportableVariants,
-            @NotNull List<PurpleGainLoss> gainsAndLosses, @NotNull List<HomozygousDisruption> homozygousDisruptions) {
+            @NotNull List<PurpleGainLoss> gainsAndLosses, @NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
         Set<String> genesDisplay = Sets.newTreeSet();
 
         for (ReportableVariant variant : reportableVariants) {
@@ -245,7 +245,7 @@ public final class SomaticVariants {
             }
         }
 
-        for (HomozygousDisruption homozygousDisruption : homozygousDisruptions) {
+        for (LinxHomozygousDisruption homozygousDisruption : homozygousDisruptions) {
             if (Genes.MSI_GENES.contains(homozygousDisruption.gene())) {
                 genesDisplay.add(CurationFunctions.curateGeneNamePdf(homozygousDisruption.gene()));
             }
@@ -255,7 +255,7 @@ public final class SomaticVariants {
 
     @NotNull
     public static Set<String> determineHRDGenes(@NotNull List<ReportableVariant> reportableVariants,
-            @NotNull List<PurpleGainLoss> gainsAndLosses, @NotNull List<HomozygousDisruption> homozygousDisruptions) {
+            @NotNull List<PurpleGainLoss> gainsAndLosses, @NotNull List<LinxHomozygousDisruption> homozygousDisruptions) {
         Set<String> genesDisplay = Sets.newTreeSet();
 
         for (ReportableVariant variant : reportableVariants) {
@@ -271,7 +271,7 @@ public final class SomaticVariants {
             }
         }
 
-        for (HomozygousDisruption homozygousDisruption : homozygousDisruptions) {
+        for (LinxHomozygousDisruption homozygousDisruption : homozygousDisruptions) {
             if (Genes.HRD_GENES.contains(homozygousDisruption.gene())) {
                 genesDisplay.add(CurationFunctions.curateGeneNamePdf(homozygousDisruption.gene()));
             }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/ViralPresence.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/cfreport/data/ViralPresence.java
@@ -3,9 +3,9 @@ package com.hartwig.oncoact.patientreporter.cfreport.data;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
+import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,12 +16,12 @@ public final class ViralPresence {
     }
 
     @NotNull
-    public static Set<String> virusInterpretationSummary(@NotNull Iterable<AnnotatedVirus> reportableViruses) {
+    public static Set<String> virusInterpretationSummary(@NotNull Iterable<VirusInterpreterEntry> reportableViruses) {
         Set<VirusInterpretation> positiveHighDriverInterpretations = Sets.newHashSet();
         Set<String> virusInterpretationSummary = Sets.newHashSet();
 
-        for (AnnotatedVirus virus : reportableViruses) {
-            if (virus.virusDriverLikelihoodType() == VirusLikelihoodType.HIGH) {
+        for (VirusInterpreterEntry virus : reportableViruses) {
+            if (virus.driverLikelihood() == VirusLikelihoodType.HIGH) {
                 VirusInterpretation virusInterpretation = virus.interpretation();
                 if (virus.interpretation() != null) {
                     assert virusInterpretation != null;
@@ -51,18 +51,18 @@ public final class ViralPresence {
     }
 
     @NotNull
-    public static String percentageCovered(@NotNull AnnotatedVirus virus) {
+    public static String percentageCovered(@NotNull VirusInterpreterEntry virus) {
         return Math.round(virus.percentageCovered()) + "%";
     }
 
     @NotNull
-    public static String integrations(@NotNull AnnotatedVirus virus) {
+    public static String integrations(@NotNull VirusInterpreterEntry virus) {
         return virus.integrations() == 0 ? "Detected without integration sites" : Integer.toString(virus.integrations());
     }
 
     @NotNull
-    public static String driverLikelihood(@NotNull AnnotatedVirus virus) {
-        switch (virus.virusDriverLikelihoodType()) {
+    public static String driverLikelihood(@NotNull VirusInterpreterEntry virus) {
+        switch (virus.driverLikelihood()) {
             case HIGH: {
                 return "High";
             }

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/qcfail/QCFailReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/qcfail/QCFailReporter.java
@@ -1,5 +1,7 @@
 package com.hartwig.oncoact.patientreporter.qcfail;
 
+import static com.hartwig.oncoact.purple.QcInterpretation.containsTumorCells;
+
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.List;
@@ -63,7 +65,7 @@ public class QCFailReporter {
             OrangeRecord orange = OrangeJson.read(config.orangeJson());
 
             String formattedPurity = new DecimalFormat("#'%'").format(orange.purple().fit().purity() * 100);
-            hasReliablePurity = orange.purple().fit().containsTumorCells();
+            hasReliablePurity = containsTumorCells(orange.purple().fit());
 
             wgsPurityString = hasReliablePurity ? formattedPurity : "N/A";
             purpleQc = orange.purple().fit().qc().status();

--- a/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/xml/XMLFactory.java
+++ b/patient-reporter/src/main/java/com/hartwig/oncoact/patientreporter/xml/XMLFactory.java
@@ -7,10 +7,10 @@ import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
 import com.hartwig.oncoact.patientreporter.QsFormNumber;
 import com.hartwig.oncoact.patientreporter.algo.AnalysedPatientReport;
@@ -188,10 +188,10 @@ public class XMLFactory {
         }
     }
 
-    public static void addHomozygousDisruptionsToXML(@NotNull List<HomozygousDisruption> homozygousDisruptions,
+    public static void addHomozygousDisruptionsToXML(@NotNull List<LinxHomozygousDisruption> homozygousDisruptions,
             @NotNull List<KeyXML> xmlList) {
         int count = 1;
-        for (HomozygousDisruption homozygousDisruption : HomozygousDisruptions.sort(homozygousDisruptions)) {
+        for (LinxHomozygousDisruption homozygousDisruption : HomozygousDisruptions.sort(homozygousDisruptions)) {
             xmlList.add(ImmutableKeyXML.builder()
                     .keyPath("importwgs.wgshzy.line[" + count + "]gen")
                     .valuePath(Map.of("value", homozygousDisruption.gene()))
@@ -259,9 +259,9 @@ public class XMLFactory {
         }
     }
 
-    public static void addVirussesToXML(@NotNull List<AnnotatedVirus> annotatedVirusList, @NotNull List<KeyXML> xmlList) {
+    public static void addVirussesToXML(@NotNull List<VirusInterpreterEntry> annotatedVirusList, @NotNull List<KeyXML> xmlList) {
         int count = 1;
-        for (AnnotatedVirus virus : annotatedVirusList) {
+        for (VirusInterpreterEntry virus : annotatedVirusList) {
             xmlList.add(ImmutableKeyXML.builder()
                     .keyPath("importwgs.wgsvrs.line[" + count + "]name")
                     .valuePath(Map.of("value", virus.name()))
@@ -276,7 +276,7 @@ public class XMLFactory {
         for (LinxFusion fusion : GeneFusions.sort(linxFusions)) {
             xmlList.add(ImmutableKeyXML.builder()
                     .keyPath("importwgs.wgsfusie.line[" + count + "]name")
-                    .valuePath(Map.of("value", fusion.name()))
+                    .valuePath(Map.of("value", fusion.display()))
                     .build());
             xmlList.add(ImmutableKeyXML.builder()
                     .keyPath("importwgs.wgsfusie.line[" + count + "]f5gen")
@@ -312,7 +312,7 @@ public class XMLFactory {
                     .build());
             xmlList.add(ImmutableKeyXML.builder()
                     .keyPath("importwgs.wgsfusie.line[" + count + "]driver")
-                    .valuePath(Map.of("value", fusion.likelihood().name()))
+                    .valuePath(Map.of("value", fusion.driverLikelihood().name()))
                     .build());
             count += 1;
         }

--- a/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/ExampleAnalysisTestFactory.java
+++ b/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/ExampleAnalysisTestFactory.java
@@ -13,12 +13,12 @@ import com.google.common.io.Resources;
 import com.hartwig.hmftools.datamodel.chord.ChordStatus;
 import com.hartwig.hmftools.datamodel.linx.FusionLikelihoodType;
 import com.hartwig.hmftools.datamodel.linx.FusionPhasedType;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.peach.PeachGenotype;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
-import com.hartwig.hmftools.datamodel.purple.Hotspot;
+import com.hartwig.hmftools.datamodel.purple.HotspotType;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
@@ -29,8 +29,8 @@ import com.hartwig.hmftools.datamodel.purple.PurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleTumorMutationalStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantType;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.oncoact.copynumber.Chromosome;
 import com.hartwig.oncoact.copynumber.ChromosomeArm;
 import com.hartwig.oncoact.copynumber.CnPerChromosomeArmData;
@@ -109,9 +109,9 @@ public final class ExampleAnalysisTestFactory {
                 notifyAllGermlineVariants(reportableVariants, reportData.lamaPatientData().getReportSettings().getFlagGermlineOnReport());
         List<PurpleGainLoss> gainsAndLosses = createCOLO829GainsLosses();
         List<LinxFusion> fusions = Lists.newArrayList();
-        List<HomozygousDisruption> homozygousDisruptions = Lists.newArrayList();
+        List<LinxHomozygousDisruption> homozygousDisruptions = Lists.newArrayList();
         List<GeneDisruption> disruptions = createCOLO829Disruptions();
-        List<AnnotatedVirus> viruses = Lists.newArrayList();
+        List<VirusInterpreterEntry> viruses = Lists.newArrayList();
         Map<String, List<PeachGenotype>> pharmacogeneticsGenotypes = createTestPharmacogeneticsGenotypes();
         HlaAllelesReportingData hlaData = createTestHlaData();
         List<InterpretPurpleGeneCopyNumbers> LOHGenes = Lists.newArrayList();
@@ -220,8 +220,8 @@ public final class ExampleAnalysisTestFactory {
         AnalysedPatientReport coloReport = createWithCOLO829Data(config, purpleQCStatus, false);
 
         List<LinxFusion> fusions = createTestFusions();
-        List<AnnotatedVirus> viruses = createTestAnnotatedViruses();
-        List<HomozygousDisruption> homozygousDisruptions = createTestHomozygousDisruptions();
+        List<VirusInterpreterEntry> viruses = createTestAnnotatedViruses();
+        List<LinxHomozygousDisruption> homozygousDisruptions = createTestHomozygousDisruptions();
 
         GenomicAnalysis analysis = ImmutableGenomicAnalysis.builder()
                 .from(coloReport.genomicAnalysis())
@@ -1793,7 +1793,7 @@ public final class ExampleAnalysisTestFactory {
                 .alleleCopyNumber(4.1)
                 .totalCopyNumber(6.02)
                 .minorAlleleCopyNumber(2.01)
-                .hotspot(Hotspot.HOTSPOT)
+                .hotspot(HotspotType.HOTSPOT)
                 .driverLikelihood(1D)
                 .clonalLikelihood(1D)
                 .biallelic(false)
@@ -1832,7 +1832,7 @@ public final class ExampleAnalysisTestFactory {
                 .alleleCopyNumber(2.02)
                 .minorAlleleCopyNumber(0.0)
                 .totalCopyNumber(2.0)
-                .hotspot(Hotspot.NEAR_HOTSPOT)
+                .hotspot(HotspotType.NEAR_HOTSPOT)
                 .clonalLikelihood(1D)
                 .driverLikelihood(1D)
                 .biallelic(true)
@@ -1864,7 +1864,7 @@ public final class ExampleAnalysisTestFactory {
                 .alleleCopyNumber(2.02)
                 .minorAlleleCopyNumber(0.0)
                 .totalCopyNumber(2.0)
-                .hotspot(Hotspot.NEAR_HOTSPOT)
+                .hotspot(HotspotType.NEAR_HOTSPOT)
                 .clonalLikelihood(1D)
                 .driverLikelihood(1D)
                 .biallelic(true)
@@ -1941,7 +1941,7 @@ public final class ExampleAnalysisTestFactory {
                 .alleleCopyNumber(2.03)
                 .minorAlleleCopyNumber(1.0)
                 .totalCopyNumber(3.02)
-                .hotspot(Hotspot.NON_HOTSPOT)
+                .hotspot(HotspotType.NON_HOTSPOT)
                 .clonalLikelihood(1D)
                 .driverLikelihood(0.1459)
                 .biallelic(false)
@@ -1973,7 +1973,7 @@ public final class ExampleAnalysisTestFactory {
                 .alleleCopyNumber(1.68)
                 .minorAlleleCopyNumber(1.97)
                 .totalCopyNumber(3.98)
-                .hotspot(Hotspot.NON_HOTSPOT)
+                .hotspot(HotspotType.NON_HOTSPOT)
                 .clonalLikelihood(1D)
                 .driverLikelihood(0D)
                 .biallelic(false)
@@ -1996,7 +1996,7 @@ public final class ExampleAnalysisTestFactory {
                 .hgvsProteinImpact(hgvsProteinImpact)
                 .affectedCodon(codon)
                 .affectedExon(exon)
-                .spliceRegion(spliceRegion)
+                .inSpliceRegion(spliceRegion)
                 .effects(effects)
                 .codingEffect(effect)
                 .build();
@@ -2023,7 +2023,6 @@ public final class ExampleAnalysisTestFactory {
         LinxFusion fusion1 = TestLinxFactory.fusionBuilder()
                 .reported(true)
                 .reportedType(LinxFusionType.KNOWN_PAIR)
-                .name(Strings.EMPTY)
                 .geneStart("TMPRSS2")
                 .geneContextStart("Intron 5")
                 .geneTranscriptStart("ENST00000398585")
@@ -2032,7 +2031,7 @@ public final class ExampleAnalysisTestFactory {
                 .geneContextEnd("Intron 3")
                 .geneTranscriptEnd("ENST00000406427")
                 .fusedExonDown(7)
-                .likelihood(FusionLikelihoodType.HIGH)
+                .driverLikelihood(FusionLikelihoodType.HIGH)
                 .phased(FusionPhasedType.INFRAME)
                 .junctionCopyNumber(0.4)
                 .build();
@@ -2040,7 +2039,6 @@ public final class ExampleAnalysisTestFactory {
         LinxFusion fusion2 = TestLinxFactory.fusionBuilder()
                 .reported(true)
                 .reportedType(LinxFusionType.PROMISCUOUS_5)
-                .name(Strings.EMPTY)
                 .geneStart("CLCN6")
                 .geneContextStart("Intron 1")
                 .geneTranscriptStart("ENST00000346436")
@@ -2049,7 +2047,7 @@ public final class ExampleAnalysisTestFactory {
                 .geneContextEnd("Intron 8")
                 .geneTranscriptEnd("ENST00000288602")
                 .fusedExonDown(7)
-                .likelihood(FusionLikelihoodType.LOW)
+                .driverLikelihood(FusionLikelihoodType.LOW)
                 .phased(FusionPhasedType.SKIPPED_EXONS)
                 .junctionCopyNumber(1D)
                 .build();
@@ -2076,7 +2074,7 @@ public final class ExampleAnalysisTestFactory {
     }
 
     @NotNull
-    private static List<HomozygousDisruption> createTestHomozygousDisruptions() {
+    private static List<LinxHomozygousDisruption> createTestHomozygousDisruptions() {
         return Lists.newArrayList(TestLinxFactory.homozygousDisruptionBuilder()
                 .chromosome("8")
                 .chromosomeBand("p22")
@@ -2161,7 +2159,7 @@ public final class ExampleAnalysisTestFactory {
     }
 
     @NotNull
-    private static List<AnnotatedVirus> createTestAnnotatedViruses() {
+    private static List<VirusInterpreterEntry> createTestAnnotatedViruses() {
         return Lists.newArrayList(TestVirusInterpreterFactory.builder()
                 .reported(true)
                 .name("Human papillomavirus type 16")

--- a/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/algo/CurationFunctionsTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/algo/CurationFunctionsTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.oncoact.disruption.GeneDisruption;
 import com.hartwig.oncoact.disruption.TestGeneDisruptionFactory;
@@ -166,8 +166,8 @@ public class CurationFunctionsTest {
 
     @Test
     public void canCurateHomozygousDisruptions() {
-        List<HomozygousDisruption> homozygousDisruptions = createTestHomozygousDisruptions();
-        List<HomozygousDisruption> curated = CurationFunctions.curateHomozygousDisruptions(homozygousDisruptions);
+        List<LinxHomozygousDisruption> homozygousDisruptions = createTestHomozygousDisruptions();
+        List<LinxHomozygousDisruption> curated = CurationFunctions.curateHomozygousDisruptions(homozygousDisruptions);
 
         assertEquals(curated.size(), 3);
         assertEquals(findByGeneHomozygousDisruption(curated, "NRAS", true), "NRAS");
@@ -176,9 +176,9 @@ public class CurationFunctionsTest {
     }
 
     @NotNull
-    private static String findByGeneHomozygousDisruption(@NotNull List<HomozygousDisruption> disruptions, @NotNull String gene,
+    private static String findByGeneHomozygousDisruption(@NotNull List<LinxHomozygousDisruption> disruptions, @NotNull String gene,
             boolean isCanonical) {
-        for (HomozygousDisruption disruption : disruptions) {
+        for (LinxHomozygousDisruption disruption : disruptions) {
             if (disruption.gene().equals(gene) && disruption.isCanonical() == isCanonical) {
                 return disruption.gene();
             }
@@ -285,10 +285,10 @@ public class CurationFunctionsTest {
     }
 
     @NotNull
-    private static List<HomozygousDisruption> createTestHomozygousDisruptions() {
-        HomozygousDisruption homozygousDisruption1 = TestLinxFactory.homozygousDisruptionBuilder().gene("NRAS").isCanonical(true).build();
-        HomozygousDisruption homozygousDisruption2 = TestLinxFactory.homozygousDisruptionBuilder().gene("CDKN2A").isCanonical(true).build();
-        HomozygousDisruption homozygousDisruption3 =
+    private static List<LinxHomozygousDisruption> createTestHomozygousDisruptions() {
+        LinxHomozygousDisruption homozygousDisruption1 = TestLinxFactory.homozygousDisruptionBuilder().gene("NRAS").isCanonical(true).build();
+        LinxHomozygousDisruption homozygousDisruption2 = TestLinxFactory.homozygousDisruptionBuilder().gene("CDKN2A").isCanonical(true).build();
+        LinxHomozygousDisruption homozygousDisruption3 =
                 TestLinxFactory.homozygousDisruptionBuilder().gene("CDKN2A").isCanonical(false).build();
         return Lists.newArrayList(homozygousDisruption1, homozygousDisruption2, homozygousDisruption3);
     }

--- a/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/cfreport/data/SomaticVariantsTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/oncoact/patientreporter/cfreport/data/SomaticVariantsTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
@@ -55,7 +55,7 @@ public class SomaticVariantsTest {
                 .transcript(transcript)
                 .hgvsCodingImpact(hgvsCodingImpact)
                 .hgvsProteinImpact(hgvsProteinImpact)
-                .spliceRegion(false)
+                .inSpliceRegion(false)
                 .codingEffect(PurpleCodingEffect.UNDEFINED)
                 .build();
     }
@@ -234,7 +234,7 @@ public class SomaticVariantsTest {
 
         List<PurpleGainLoss> gainLosses = Lists.newArrayList(gainLoss1, gainLoss2, gainLoss3);
 
-        List<HomozygousDisruption> homozygousDisruption = Lists.newArrayList(createHomozygousDisruption("PMS2"));
+        List<LinxHomozygousDisruption> homozygousDisruption = Lists.newArrayList(createHomozygousDisruption("PMS2"));
 
         assertEquals(4, SomaticVariants.determineMSIGenes(variants, gainLosses, homozygousDisruption).size());
     }
@@ -265,13 +265,13 @@ public class SomaticVariantsTest {
 
         List<PurpleGainLoss> gainLosses = Lists.newArrayList(gainLoss1, gainLoss2, gainLoss3);
 
-        List<HomozygousDisruption> homozygousDisruption = Lists.newArrayList(createHomozygousDisruption("RAD51C"));
+        List<LinxHomozygousDisruption> homozygousDisruption = Lists.newArrayList(createHomozygousDisruption("RAD51C"));
 
         assertEquals(4, SomaticVariants.determineHRDGenes(variants, gainLosses, homozygousDisruption).size());
     }
 
     @NotNull
-    private static HomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
+    private static LinxHomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
         return TestLinxFactory.homozygousDisruptionBuilder().gene(gene).build();
     }
 

--- a/patient-reporter/src/test/resources/test_run/orange/sample.orange.json
+++ b/patient-reporter/src/test/resources/test_run/orange/sample.orange.json
@@ -1,6 +1,7 @@
 {
   "sampleId": "TEST",
-  "experimentDate": {
+  "experimentType": "WHOLE_GENOME",
+  "samplingDate": {
     "year": 2022,
     "month": 1,
     "day": 20
@@ -50,8 +51,6 @@
         "amberMeanDepth": 111
       },
       "fittedPurityMethod": "NORMAL",
-      "hasSufficientQuality": true,
-      "containsTumorCells": false,
       "purity": 0.12,
       "minPurity": 0.97,
       "maxPurity": 1.0,
@@ -73,7 +72,7 @@
       {
         "gene": "SF3B1",
         "transcript": "ENST00000335508",
-        "driver": "MUTATION",
+        "type": "MUTATION",
         "driverLikelihood": 0.2,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -81,7 +80,7 @@
       {
         "gene": "SMAD4",
         "transcript": "ENST00000342988",
-        "driver": "DEL",
+        "type": "DEL",
         "driverLikelihood": 1.0,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -91,7 +90,7 @@
       {
         "gene": "BRCA1",
         "transcript": "ENST00000471181",
-        "driver": "GERMLINE_MUTATION",
+        "type": "GERMLINE_MUTATION",
         "driverLikelihood": 0.8,
         "likelihoodMethod": "HOTSPOT",
         "isCanonical": false
@@ -114,11 +113,12 @@
           "hgvsProteinImpact": "p.Pro718Leu",
           "affectedCodon": 2153,
           "affectedExon": 12,
-          "spliceRegion": false,
+          "inSpliceRegion": false,
           "effects": [
             "MISSENSE"
           ],
-          "codingEffect": "MISSENSE"
+          "codingEffect": "MISSENSE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "NON_HOTSPOT",
@@ -153,11 +153,12 @@
           "hgvsProteinImpact": "p.Pro718Leu",
           "affectedCodon": 2153,
           "affectedExon": 12,
-          "spliceRegion": false,
+          "inSpliceRegion": false,
           "effects": [
             "MISSENSE"
           ],
-          "codingEffect": "MISSENSE"
+          "codingEffect": "MISSENSE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "NON_HOTSPOT",
@@ -192,12 +193,13 @@
           "hgvsProteinImpact": "p.?",
           "affectedCodon": null,
           "affectedExon": null,
-          "spliceRegion": true,
+          "inSpliceRegion": true,
           "effects": [
             "SPLICE_DONOR",
             "INTRONIC"
           ],
-          "codingEffect": "SPLICE"
+          "codingEffect": "SPLICE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "HOTSPOT",
@@ -235,12 +237,13 @@
           "hgvsProteinImpact": "p.?",
           "affectedCodon": null,
           "affectedExon": null,
-          "spliceRegion": true,
+          "inSpliceRegion": true,
           "effects": [
             "SPLICE_DONOR",
             "INTRONIC"
           ],
-          "codingEffect": "SPLICE"
+          "codingEffect": "SPLICE",
+          "reported": true
         },
         "otherImpacts": [],
         "hotspot": "HOTSPOT",
@@ -271,10 +274,11 @@
     ],
     "allSomaticGeneCopyNumbers": [
       {
-        "geneName": "gene",
+        "gene": "gene",
         "chromosome": "12",
         "chromosomeBand": "p13",
         "minCopyNumber": 1.2,
+        "maxCopyNumber": 1.2,
         "minMinorAlleleCopyNumber": 0.4
       }
     ],
@@ -286,8 +290,8 @@
         "gene": "SMAD4",
         "transcript": "ENST00000591126",
         "isCanonical": false,
-        "minCopies": 0,
-        "maxCopies": 1
+        "minCopies": 0.1,
+        "maxCopies": 1.2
       }
     ],
     "reportableSomaticGainsLosses": [
@@ -298,16 +302,17 @@
         "gene": "SMAD4",
         "transcript": "ENST00000591126",
         "isCanonical": false,
-        "minCopies": 0,
-        "maxCopies": 1
+        "minCopies": 0.1,
+        "maxCopies": 1.2
       }
     ],
     "suspectGeneCopyNumbersWithLOH": [
       {
-        "geneName": "gene",
+        "gene": "gene",
         "chromosome": "12",
         "chromosomeBand": "p13",
         "minCopyNumber": 1.2,
+        "maxCopyNumber": 1.2,
         "minMinorAlleleCopyNumber": 0.4
       }
     ]
@@ -340,7 +345,7 @@
       {
         "reported": true,
         "reportedType": "KNOWN_PAIR",
-        "likelihood": "HIGH",
+        "driverLikelihood": "HIGH",
         "fusedExonUp": 1,
         "fusedExonDown": 2,
         "name": "TMPRSS2-ETV4",
@@ -362,7 +367,7 @@
       {
         "reported": true,
         "reportedType": "KNOWN_PAIR",
-        "likelihood": "HIGH",
+        "driverLikelihood": "HIGH",
         "fusedExonUp": 1,
         "fusedExonDown": 2,
         "name": "TMPRSS2-ETV4",
@@ -382,15 +387,15 @@
     ],
     "allSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -406,15 +411,15 @@
     ],
     "reportableSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -439,15 +444,15 @@
     ],
     "additionalSuspectSomaticBreakends": [
       {
-        "reportedDisruption": false,
+        "reported": false,
         "disruptive": false,
         "id": 0,
         "svId": 1,
         "gene": "NF1",
         "chromosome": "1",
-        "chrBand": "p12",
-        "transcriptId": "trans",
-        "canonical": true,
+        "chromosomeBand": "p12",
+        "transcript": "trans",
+        "isCanonical": true,
         "type": "DUP",
         "junctionCopyNumber": 1.1,
         "undisruptedCopyNumber": 1.0,
@@ -471,7 +476,7 @@
         "integrations": 1,
         "interpretation": "HPV",
         "reported": true,
-        "virusDriverLikelihoodType": "HIGH",
+        "driverLikelihood": "HIGH",
         "percentageCovered": 0.9,
         "meanCoverage": 0
       },
@@ -481,7 +486,7 @@
         "integrations": 0,
         "interpretation": null,
         "reported": false,
-        "virusDriverLikelihoodType": "LOW",
+        "driverLikelihood": "LOW",
         "percentageCovered": 0.4,
         "meanCoverage": 0
       }
@@ -493,7 +498,7 @@
         "integrations": 1,
         "interpretation": "HPV",
         "reported": true,
-        "virusDriverLikelihoodType": "HIGH",
+        "driverLikelihood": "HIGH",
         "percentageCovered": 0.9,
         "meanCoverage": 0
       }
@@ -518,10 +523,24 @@
     }
   ],
   "cuppa": {
+    "bestPrediction": {
+      "cancerType": "Melanoma",
+      "likelihood": 0.996,
+      "snvPairwiseClassifier": 0.979,
+      "genomicPositionClassifier": 0.990,
+      "featureClassifier": 0.972,
+      "altSjCohortClassifier": null,
+      "expressionPairwiseClassifier": null
+    },
     "predictions": [
       {
         "cancerType": "Melanoma",
-        "likelihood": 0.996
+        "likelihood": 0.996,
+        "snvPairwiseClassifier": 0.979,
+        "genomicPositionClassifier": 0.990,
+        "featureClassifier": 0.972,
+        "altSjCohortClassifier": null,
+        "expressionPairwiseClassifier": null
       }
     ],
     "simpleDups32To200B": 0,
@@ -553,6 +572,7 @@
     "purpleClonalityPlot": "",
     "purpleCopyNumberPlot": "",
     "purpleVariantCopyNumberPlot": "",
-    "purplePurityRangePlot": ""
+    "purplePurityRangePlot": "",
+    "purpleKataegisPlot": ""
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <rose.version>2.0.1</rose.version>
 
         <serve.version>2.4.0</serve.version>
-        <orange-datamodel.version>1.3.3</orange-datamodel.version>
+        <orange-datamodel.version>2.3.0</orange-datamodel.version>
         <lama-client.version>2.3.7</lama-client.version>
         <silo-diagnostic-client.version>3.0.6</silo-diagnostic-client.version>
 

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/DisruptionEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/DisruptionEvidence.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.hartwig.oncoact.util.ListUtil;
 import com.hartwig.serve.datamodel.gene.ActionableGene;
@@ -32,10 +32,10 @@ public class DisruptionEvidence {
     }
 
     @NotNull
-    public List<ProtectEvidence> evidence(@NotNull List<HomozygousDisruption> somaticHomozygousDisruptions,
-            @Nullable List<HomozygousDisruption> germlineHomozygousDisruptions) {
+    public List<ProtectEvidence> evidence(@NotNull List<LinxHomozygousDisruption> somaticHomozygousDisruptions,
+            @Nullable List<LinxHomozygousDisruption> germlineHomozygousDisruptions) {
         List<ProtectEvidence> result = Lists.newArrayList();
-        for (HomozygousDisruption homozygousDisruption : ListUtil.mergeListsDistinct(somaticHomozygousDisruptions,
+        for (LinxHomozygousDisruption homozygousDisruption : ListUtil.mergeListsDistinct(somaticHomozygousDisruptions,
                 germlineHomozygousDisruptions)) {
             result.addAll(evidence(homozygousDisruption));
         }
@@ -43,7 +43,7 @@ public class DisruptionEvidence {
     }
 
     @NotNull
-    private List<ProtectEvidence> evidence(@NotNull HomozygousDisruption homozygousDisruption) {
+    private List<ProtectEvidence> evidence(@NotNull LinxHomozygousDisruption homozygousDisruption) {
         List<ProtectEvidence> result = Lists.newArrayList();
         for (ActionableGene actionable : actionableGenes) {
             if (actionable.gene().equals(homozygousDisruption.gene())) {

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/FusionEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/FusionEvidence.java
@@ -2,7 +2,6 @@ package com.hartwig.oncoact.protect.evidence;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
@@ -81,7 +80,7 @@ public class FusionEvidence {
                 .reported(false)
                 .gene(geneFromActionable(actionable))
                 .event(EventGenerator.fusionEvent(fusion))
-                .eventIsHighDriver(EvidenceDriverLikelihood.interpretFusion(fusion.likelihood()))
+                .eventIsHighDriver(EvidenceDriverLikelihood.interpretFusion(fusion.driverLikelihood()))
                 .build();
     }
 
@@ -91,7 +90,7 @@ public class FusionEvidence {
                 .reported(fusion.reported())
                 .gene(geneFromActionable(actionable))
                 .event(EventGenerator.fusionEvent(fusion))
-                .eventIsHighDriver(EvidenceDriverLikelihood.interpretFusion(fusion.likelihood()))
+                .eventIsHighDriver(EvidenceDriverLikelihood.interpretFusion(fusion.driverLikelihood()))
                 .build();
     }
 

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VariantEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VariantEvidence.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Lists;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariant;
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantType;
-import com.hartwig.hmftools.datamodel.purple.Variant;
 import com.hartwig.oncoact.protect.EventGenerator;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.hartwig.oncoact.variant.DriverInterpretation;
@@ -74,7 +73,7 @@ public class VariantEvidence {
     }
 
     @NotNull
-    private List<ProtectEvidence> evidence(@NotNull Variant variant) {
+    private List<ProtectEvidence> evidence(@NotNull ReportableVariant variant) {
         boolean mayReport;
         DriverInterpretation driverInterpretation;
 
@@ -116,7 +115,86 @@ public class VariantEvidence {
     }
 
     @NotNull
-    private ProtectEvidence evidence(@NotNull Variant variant, @NotNull ActionableEvent actionable, boolean report, @NotNull String range) {
+    private List<ProtectEvidence> evidence(@NotNull PurpleVariant variant) {
+        boolean mayReport;
+        DriverInterpretation driverInterpretation;
+
+        if (variant instanceof ReportableVariant) {
+            ReportableVariant reportable = (ReportableVariant) variant;
+            mayReport = true;
+            driverInterpretation = reportable.driverLikelihoodInterpretation();
+        } else {
+            mayReport = false;
+            driverInterpretation = DriverInterpretation.LOW;
+        }
+
+        List<ProtectEvidence> evidences = Lists.newArrayList();
+        for (ActionableHotspot hotspot : hotspots) {
+            if (hotspotMatch(variant, hotspot)) {
+                evidences.add(evidence(variant, hotspot, mayReport, "hotspot"));
+            }
+        }
+
+        for (ActionableRange codon : codons) {
+            if (rangeMatch(variant, codon)) {
+                evidences.add(evidence(variant, codon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "codon"));
+            }
+        }
+
+        for (ActionableRange exon : exons) {
+            if (rangeMatch(variant, exon)) {
+                evidences.add(evidence(variant, exon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "exon"));
+            }
+        }
+
+        for (ActionableGene gene : genes) {
+            if (geneMatch(variant, gene)) {
+                evidences.add(evidence(variant, gene, mayReport && driverInterpretation == DriverInterpretation.HIGH, "gene"));
+            }
+        }
+
+        return evidences;
+    }
+
+    @NotNull
+    private ProtectEvidence evidence(@NotNull ReportableVariant variant, @NotNull ActionableEvent actionable, boolean report, @NotNull String range) {
+        boolean isGermline;
+        DriverInterpretation driverInterpretation;
+        String transcript;
+        boolean isCanonical;
+        Integer rangeRank;
+        if (variant instanceof ReportableVariant) {
+            ReportableVariant reportable = (ReportableVariant) variant;
+            isGermline =
+                    reportable.source() == ReportableVariantSource.GERMLINE || reportable.source() == ReportableVariantSource.GERMLINE_ONLY;
+            driverInterpretation = reportable.driverLikelihoodInterpretation();
+            transcript = reportable.transcript();
+            isCanonical = reportable.isCanonical();
+            rangeRank = determineRangeRank(range, reportable.affectedCodon(), reportable.affectedExon());
+        } else if (variant instanceof PurpleVariant) {
+            PurpleVariant purple = (PurpleVariant) variant;
+            isGermline = false;
+            driverInterpretation = DriverInterpretation.LOW;
+            transcript = purple.canonicalImpact().transcript();
+            isCanonical = true;
+            rangeRank = determineRangeRank(range, purple.canonicalImpact().affectedCodon(), purple.canonicalImpact().affectedExon());
+        } else {
+            throw new IllegalArgumentException(String.format("Variant of type '%s' not supported", variant.getClass().getName()));
+        }
+
+        return personalizedEvidenceFactory.evidenceBuilderRange(actionable, range, rangeRank)
+                .gene(variant.gene())
+                .transcript(transcript)
+                .isCanonical(isCanonical)
+                .event(EventGenerator.variantEvent(variant))
+                .germline(isGermline)
+                .reported(report)
+                .eventIsHighDriver(driverInterpretation == null ? null : EvidenceDriverLikelihood.interpretVariant(driverInterpretation))
+                .build();
+    }
+
+    @NotNull
+    private ProtectEvidence evidence(@NotNull PurpleVariant variant, @NotNull ActionableEvent actionable, boolean report, @NotNull String range) {
         boolean isGermline;
         DriverInterpretation driverInterpretation;
         String transcript;
@@ -166,23 +244,39 @@ public class VariantEvidence {
         }
     }
 
-    private static boolean hotspotMatch(@NotNull Variant variant, @NotNull ActionableHotspot hotspot) {
+    private static boolean hotspotMatch(@NotNull ReportableVariant variant, @NotNull ActionableHotspot hotspot) {
         return variant.chromosome().equals(hotspot.chromosome()) && hotspot.position() == variant.position() && hotspot.ref()
                 .equals(variant.ref()) && hotspot.alt().equals(variant.alt());
     }
 
-    private static boolean rangeMatch(@NotNull Variant variant, @NotNull ActionableRange range) {
+    private static boolean hotspotMatch(@NotNull PurpleVariant variant, @NotNull ActionableHotspot hotspot) {
+        return variant.chromosome().equals(hotspot.chromosome()) && hotspot.position() == variant.position() && hotspot.ref()
+                .equals(variant.ref()) && hotspot.alt().equals(variant.alt());
+    }
+
+    private static boolean rangeMatch(@NotNull ReportableVariant variant, @NotNull ActionableRange range) {
         return variant.chromosome().equals(range.chromosome()) && variant.gene().equals(range.gene()) && variant.position() >= range.start()
                 && variant.position() <= range.end() && meetsMutationType(variant, range.applicableMutationType());
     }
 
-    private static boolean geneMatch(@NotNull Variant variant, @NotNull ActionableGene gene) {
+    private static boolean rangeMatch(@NotNull PurpleVariant variant, @NotNull ActionableRange range) {
+        return variant.chromosome().equals(range.chromosome()) && variant.gene().equals(range.gene()) && variant.position() >= range.start()
+                && variant.position() <= range.end() && meetsMutationType(variant, range.applicableMutationType());
+    }
+
+    private static boolean geneMatch(@NotNull ReportableVariant variant, @NotNull ActionableGene gene) {
         assert gene.event() == GeneEvent.ACTIVATION || gene.event() == GeneEvent.INACTIVATION || gene.event() == GeneEvent.ANY_MUTATION;
 
         return gene.gene().equals(variant.gene()) && meetsMutationType(variant, MutationType.ANY);
     }
 
-    private static boolean meetsMutationType(@NotNull Variant variant, @NotNull MutationType applicableMutationType) {
+    private static boolean geneMatch(@NotNull PurpleVariant variant, @NotNull ActionableGene gene) {
+        assert gene.event() == GeneEvent.ACTIVATION || gene.event() == GeneEvent.INACTIVATION || gene.event() == GeneEvent.ANY_MUTATION;
+
+        return gene.gene().equals(variant.gene()) && meetsMutationType(variant, MutationType.ANY);
+    }
+
+    private static boolean meetsMutationType(@NotNull ReportableVariant variant, @NotNull MutationType applicableMutationType) {
         PurpleCodingEffect effect;
         if (variant instanceof ReportableVariant) {
             ReportableVariant reportable = (ReportableVariant) variant;
@@ -217,11 +311,54 @@ public class VariantEvidence {
         }
     }
 
-    private static boolean isInsert(@NotNull Variant variant) {
+    private static boolean meetsMutationType(@NotNull PurpleVariant variant, @NotNull MutationType applicableMutationType) {
+        PurpleCodingEffect effect;
+        if (variant instanceof ReportableVariant) {
+            ReportableVariant reportable = (ReportableVariant) variant;
+            effect = reportable.canonicalCodingEffect();
+        } else if (variant instanceof PurpleVariant) {
+            PurpleVariant purple = (PurpleVariant) variant;
+            effect = purple.canonicalImpact().codingEffect();
+        } else {
+            throw new IllegalArgumentException("Variant is defined in a wrong variant other than ReportableVariant and PurpleVariant");
+        }
+
+        switch (applicableMutationType) {
+            case NONSENSE_OR_FRAMESHIFT:
+                return effect == PurpleCodingEffect.NONSENSE_OR_FRAMESHIFT;
+            case SPLICE:
+                return effect == PurpleCodingEffect.SPLICE;
+            case INFRAME:
+                return effect == PurpleCodingEffect.MISSENSE && variant.type() == PurpleVariantType.INDEL;
+            case INFRAME_DELETION:
+                return effect == PurpleCodingEffect.MISSENSE && isDelete(variant);
+            case INFRAME_INSERTION:
+                return effect == PurpleCodingEffect.MISSENSE && isInsert(variant);
+            case MISSENSE:
+                return effect == PurpleCodingEffect.MISSENSE;
+            case ANY:
+                return effect == PurpleCodingEffect.MISSENSE || effect == PurpleCodingEffect.NONSENSE_OR_FRAMESHIFT
+                        || effect == PurpleCodingEffect.SPLICE;
+            default: {
+                LOGGER.warn("Unrecognized mutation type filter: '{}'", applicableMutationType);
+                return false;
+            }
+        }
+    }
+
+    private static boolean isInsert(@NotNull ReportableVariant variant) {
         return variant.type() == PurpleVariantType.INDEL && variant.alt().length() > variant.ref().length();
     }
 
-    private static boolean isDelete(@NotNull Variant variant) {
+    private static boolean isInsert(@NotNull PurpleVariant variant) {
+        return variant.type() == PurpleVariantType.INDEL && variant.alt().length() > variant.ref().length();
+    }
+
+    private static boolean isDelete(@NotNull ReportableVariant variant) {
+        return variant.type() == PurpleVariantType.INDEL && variant.alt().length() < variant.ref().length();
+    }
+
+    private static boolean isDelete(@NotNull PurpleVariant variant) {
         return variant.type() == PurpleVariantType.INDEL && variant.alt().length() < variant.ref().length();
     }
 }

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VariantEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VariantEvidence.java
@@ -74,40 +74,30 @@ public class VariantEvidence {
 
     @NotNull
     private List<ProtectEvidence> evidence(@NotNull ReportableVariant variant) {
-        boolean mayReport;
-        DriverInterpretation driverInterpretation;
-
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            mayReport = true;
-            driverInterpretation = reportable.driverLikelihoodInterpretation();
-        } else {
-            mayReport = false;
-            driverInterpretation = DriverInterpretation.LOW;
-        }
+        DriverInterpretation driverInterpretation = variant.driverLikelihoodInterpretation();
 
         List<ProtectEvidence> evidences = Lists.newArrayList();
         for (ActionableHotspot hotspot : hotspots) {
             if (hotspotMatch(variant, hotspot)) {
-                evidences.add(evidence(variant, hotspot, mayReport, "hotspot"));
+                evidences.add(evidence(variant, hotspot, true, "hotspot"));
             }
         }
 
         for (ActionableRange codon : codons) {
             if (rangeMatch(variant, codon)) {
-                evidences.add(evidence(variant, codon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "codon"));
+                evidences.add(evidence(variant, codon, driverInterpretation == DriverInterpretation.HIGH, "codon"));
             }
         }
 
         for (ActionableRange exon : exons) {
             if (rangeMatch(variant, exon)) {
-                evidences.add(evidence(variant, exon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "exon"));
+                evidences.add(evidence(variant, exon, driverInterpretation == DriverInterpretation.HIGH, "exon"));
             }
         }
 
         for (ActionableGene gene : genes) {
             if (geneMatch(variant, gene)) {
-                evidences.add(evidence(variant, gene, mayReport && driverInterpretation == DriverInterpretation.HIGH, "gene"));
+                evidences.add(evidence(variant, gene, driverInterpretation == DriverInterpretation.HIGH, "gene"));
             }
         }
 
@@ -116,40 +106,28 @@ public class VariantEvidence {
 
     @NotNull
     private List<ProtectEvidence> evidence(@NotNull PurpleVariant variant) {
-        boolean mayReport;
-        DriverInterpretation driverInterpretation;
-
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            mayReport = true;
-            driverInterpretation = reportable.driverLikelihoodInterpretation();
-        } else {
-            mayReport = false;
-            driverInterpretation = DriverInterpretation.LOW;
-        }
-
         List<ProtectEvidence> evidences = Lists.newArrayList();
         for (ActionableHotspot hotspot : hotspots) {
             if (hotspotMatch(variant, hotspot)) {
-                evidences.add(evidence(variant, hotspot, mayReport, "hotspot"));
+                evidences.add(evidence(variant, hotspot, false, "hotspot"));
             }
         }
 
         for (ActionableRange codon : codons) {
             if (rangeMatch(variant, codon)) {
-                evidences.add(evidence(variant, codon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "codon"));
+                evidences.add(evidence(variant, codon, false, "codon"));
             }
         }
 
         for (ActionableRange exon : exons) {
             if (rangeMatch(variant, exon)) {
-                evidences.add(evidence(variant, exon, mayReport && driverInterpretation == DriverInterpretation.HIGH, "exon"));
+                evidences.add(evidence(variant, exon, false, "exon"));
             }
         }
 
         for (ActionableGene gene : genes) {
             if (geneMatch(variant, gene)) {
-                evidences.add(evidence(variant, gene, mayReport && driverInterpretation == DriverInterpretation.HIGH, "gene"));
+                evidences.add(evidence(variant, gene, false, "gene"));
             }
         }
 
@@ -163,24 +141,11 @@ public class VariantEvidence {
         String transcript;
         boolean isCanonical;
         Integer rangeRank;
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            isGermline =
-                    reportable.source() == ReportableVariantSource.GERMLINE || reportable.source() == ReportableVariantSource.GERMLINE_ONLY;
-            driverInterpretation = reportable.driverLikelihoodInterpretation();
-            transcript = reportable.transcript();
-            isCanonical = reportable.isCanonical();
-            rangeRank = determineRangeRank(range, reportable.affectedCodon(), reportable.affectedExon());
-        } else if (variant instanceof PurpleVariant) {
-            PurpleVariant purple = (PurpleVariant) variant;
-            isGermline = false;
-            driverInterpretation = DriverInterpretation.LOW;
-            transcript = purple.canonicalImpact().transcript();
-            isCanonical = true;
-            rangeRank = determineRangeRank(range, purple.canonicalImpact().affectedCodon(), purple.canonicalImpact().affectedExon());
-        } else {
-            throw new IllegalArgumentException(String.format("Variant of type '%s' not supported", variant.getClass().getName()));
-        }
+        isGermline = variant.source() == ReportableVariantSource.GERMLINE || variant.source() == ReportableVariantSource.GERMLINE_ONLY;
+        driverInterpretation = variant.driverLikelihoodInterpretation();
+        transcript = variant.transcript();
+        isCanonical = variant.isCanonical();
+        rangeRank = determineRangeRank(range, variant.affectedCodon(), variant.affectedExon());
 
         return personalizedEvidenceFactory.evidenceBuilderRange(actionable, range, rangeRank)
                 .gene(variant.gene())
@@ -200,24 +165,12 @@ public class VariantEvidence {
         String transcript;
         boolean isCanonical;
         Integer rangeRank;
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            isGermline =
-                    reportable.source() == ReportableVariantSource.GERMLINE || reportable.source() == ReportableVariantSource.GERMLINE_ONLY;
-            driverInterpretation = reportable.driverLikelihoodInterpretation();
-            transcript = reportable.transcript();
-            isCanonical = reportable.isCanonical();
-            rangeRank = determineRangeRank(range, reportable.affectedCodon(), reportable.affectedExon());
-        } else if (variant instanceof PurpleVariant) {
-            PurpleVariant purple = (PurpleVariant) variant;
-            isGermline = false;
-            driverInterpretation = DriverInterpretation.LOW;
-            transcript = purple.canonicalImpact().transcript();
-            isCanonical = true;
-            rangeRank = determineRangeRank(range, purple.canonicalImpact().affectedCodon(), purple.canonicalImpact().affectedExon());
-        } else {
-            throw new IllegalArgumentException(String.format("Variant of type '%s' not supported", variant.getClass().getName()));
-        }
+
+        isGermline = false;
+        driverInterpretation = DriverInterpretation.LOW;
+        transcript = variant.canonicalImpact().transcript();
+        isCanonical = true;
+        rangeRank = determineRangeRank(range, variant.canonicalImpact().affectedCodon(), variant.canonicalImpact().affectedExon());
 
         return personalizedEvidenceFactory.evidenceBuilderRange(actionable, range, rangeRank)
                 .gene(variant.gene())
@@ -226,7 +179,7 @@ public class VariantEvidence {
                 .event(EventGenerator.variantEvent(variant))
                 .germline(isGermline)
                 .reported(report)
-                .eventIsHighDriver(driverInterpretation == null ? null : EvidenceDriverLikelihood.interpretVariant(driverInterpretation))
+                .eventIsHighDriver(EvidenceDriverLikelihood.interpretVariant(driverInterpretation))
                 .build();
     }
 
@@ -278,15 +231,7 @@ public class VariantEvidence {
 
     private static boolean meetsMutationType(@NotNull ReportableVariant variant, @NotNull MutationType applicableMutationType) {
         PurpleCodingEffect effect;
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            effect = reportable.canonicalCodingEffect();
-        } else if (variant instanceof PurpleVariant) {
-            PurpleVariant purple = (PurpleVariant) variant;
-            effect = purple.canonicalImpact().codingEffect();
-        } else {
-            throw new IllegalArgumentException("Variant is defined in a wrong variant other than ReportableVariant and PurpleVariant");
-        }
+        effect = variant.canonicalCodingEffect();
 
         switch (applicableMutationType) {
             case NONSENSE_OR_FRAMESHIFT:
@@ -313,15 +258,7 @@ public class VariantEvidence {
 
     private static boolean meetsMutationType(@NotNull PurpleVariant variant, @NotNull MutationType applicableMutationType) {
         PurpleCodingEffect effect;
-        if (variant instanceof ReportableVariant) {
-            ReportableVariant reportable = (ReportableVariant) variant;
-            effect = reportable.canonicalCodingEffect();
-        } else if (variant instanceof PurpleVariant) {
-            PurpleVariant purple = (PurpleVariant) variant;
-            effect = purple.canonicalImpact().codingEffect();
-        } else {
-            throw new IllegalArgumentException("Variant is defined in a wrong variant other than ReportableVariant and PurpleVariant");
-        }
+        effect = variant.canonicalImpact().codingEffect();
 
         switch (applicableMutationType) {
             case NONSENSE_OR_FRAMESHIFT:

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VirusEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/VirusEvidence.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
+import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.hartwig.serve.datamodel.characteristic.ActionableCharacteristic;
 import com.hartwig.serve.datamodel.characteristic.TumorCharacteristicType;
@@ -34,8 +34,8 @@ public class VirusEvidence {
 
     @NotNull
     public List<ProtectEvidence> evidence(@NotNull VirusInterpreterData virusInterpreter) {
-        List<AnnotatedVirus> hpv = virusesWithInterpretation(virusInterpreter, VirusInterpretation.HPV);
-        List<AnnotatedVirus> ebv = virusesWithInterpretation(virusInterpreter, VirusInterpretation.EBV);
+        List<VirusInterpreterEntry> hpv = virusesWithInterpretation(virusInterpreter, VirusInterpretation.HPV);
+        List<VirusInterpreterEntry> ebv = virusesWithInterpretation(virusInterpreter, VirusInterpretation.EBV);
 
         boolean reportHPV = hasReportedWithHighDriverLikelihood(hpv);
         boolean reportEBV = hasReportedWithHighDriverLikelihood(ebv);
@@ -70,9 +70,9 @@ public class VirusEvidence {
         return result;
     }
 
-    private static boolean hasReportedWithHighDriverLikelihood(@NotNull List<AnnotatedVirus> viruses) {
-        for (AnnotatedVirus virus : viruses) {
-            if (virus.reported() && virus.virusDriverLikelihoodType() == VirusLikelihoodType.HIGH) {
+    private static boolean hasReportedWithHighDriverLikelihood(@NotNull List<VirusInterpreterEntry> viruses) {
+        for (VirusInterpreterEntry virus : viruses) {
+            if (virus.reported() && virus.driverLikelihood() == VirusLikelihoodType.HIGH) {
                 return true;
             }
         }
@@ -81,16 +81,16 @@ public class VirusEvidence {
     }
 
     @NotNull
-    private static List<AnnotatedVirus> virusesWithInterpretation(@NotNull VirusInterpreterData virusInterpreter,
+    private static List<VirusInterpreterEntry> virusesWithInterpretation(@NotNull VirusInterpreterData virusInterpreter,
             @NotNull VirusInterpretation interpretationToInclude) {
-        List<AnnotatedVirus> virusesWithInterpretation = Lists.newArrayList();
-        for (AnnotatedVirus virus : virusInterpreter.reportableViruses()) {
+        List<VirusInterpreterEntry> virusesWithInterpretation = Lists.newArrayList();
+        for (VirusInterpreterEntry virus : virusInterpreter.reportableViruses()) {
             if (virus.interpretation() == interpretationToInclude) {
                 virusesWithInterpretation.add(virus);
             }
         }
 
-        for (AnnotatedVirus virus : virusInterpreter.allViruses()) {
+        for (VirusInterpreterEntry virus : virusInterpreter.allViruses()) {
             if ((!virusInterpreter.reportableViruses().contains(virus) && virus.interpretation() == interpretationToInclude)) {
                 virusesWithInterpretation.add(virus);
             }

--- a/protect/src/main/java/com/hartwig/oncoact/protect/evidence/WildTypeEvidence.java
+++ b/protect/src/main/java/com/hartwig/oncoact/protect/evidence/WildTypeEvidence.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
 import com.hartwig.oncoact.drivergene.DriverGene;
@@ -39,7 +39,7 @@ public class WildTypeEvidence {
     public List<ProtectEvidence> evidence(@NotNull Collection<ReportableVariant> reportableGermlineVariants,
             @NotNull Collection<ReportableVariant> reportableSomaticVariants,
             @NotNull Collection<PurpleGainLoss> reportableSomaticGainsLosses, @NotNull Collection<LinxFusion> reportableFusions,
-            @NotNull Collection<HomozygousDisruption> homozygousDisruptions, @NotNull Collection<LinxBreakend> reportableBreakends,
+            @NotNull Collection<LinxHomozygousDisruption> homozygousDisruptions, @NotNull Collection<LinxBreakend> reportableBreakends,
             @NotNull Collection<PurpleQCStatus> purpleQCStatus) {
         List<ProtectEvidence> evidences = Lists.newArrayList();
         List<WildTypeGene> wildTypeGenes = WildTypeFactory.determineWildTypeGenes(reportableGermlineVariants,

--- a/protect/src/test/java/com/hartwig/oncoact/protect/evidence/DisruptionEvidenceTest.java
+++ b/protect/src/test/java/com/hartwig/oncoact/protect/evidence/DisruptionEvidenceTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.oncoact.orange.linx.TestLinxFactory;
 import com.hartwig.oncoact.protect.EvidenceType;
 import com.hartwig.oncoact.protect.ProtectEvidence;
@@ -35,9 +35,9 @@ public class DisruptionEvidenceTest {
         DisruptionEvidence disruptionEvidence = new DisruptionEvidence(TestPersonalizedEvidenceFactory.create(),
                 Lists.newArrayList(amp, inactivation, deletion, underexpression));
 
-        HomozygousDisruption matchAmp = create(geneAmp);
-        HomozygousDisruption matchInact = create(geneInact);
-        HomozygousDisruption nonMatch = create("other gene");
+        LinxHomozygousDisruption matchAmp = create(geneAmp);
+        LinxHomozygousDisruption matchInact = create(geneInact);
+        LinxHomozygousDisruption nonMatch = create("other gene");
 
         List<ProtectEvidence> evidences =
                 disruptionEvidence.evidence(Lists.newArrayList(matchAmp, matchInact, nonMatch), Lists.newArrayList());
@@ -56,7 +56,7 @@ public class DisruptionEvidenceTest {
     }
 
     @NotNull
-    private static HomozygousDisruption create(@NotNull String gene) {
+    private static LinxHomozygousDisruption create(@NotNull String gene) {
         return TestLinxFactory.homozygousDisruptionBuilder().gene(gene).build();
     }
 

--- a/protect/src/test/java/com/hartwig/oncoact/protect/evidence/VirusEvidenceTest.java
+++ b/protect/src/test/java/com/hartwig/oncoact/protect/evidence/VirusEvidenceTest.java
@@ -10,10 +10,10 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
 import com.hartwig.hmftools.datamodel.virus.ImmutableVirusInterpreterData;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.oncoact.orange.virus.TestVirusInterpreterFactory;
 import com.hartwig.oncoact.protect.ProtectEvidence;
@@ -57,42 +57,42 @@ public class VirusEvidenceTest {
 
     @NotNull
     private static VirusInterpreterData createTestVirusInterpreterRecord() {
-        Set<AnnotatedVirus> reportableViruses = Sets.newHashSet();
+        Set<VirusInterpreterEntry> reportableViruses = Sets.newHashSet();
         reportableViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(true)
                 .interpretation(VirusInterpretation.HPV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .build());
         reportableViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(true)
                 .interpretation(VirusInterpretation.MCV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.LOW)
+                .driverLikelihood(VirusLikelihoodType.LOW)
                 .build());
         reportableViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(true)
                 .interpretation(VirusInterpretation.EBV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.LOW)
+                .driverLikelihood(VirusLikelihoodType.LOW)
                 .build());
         reportableViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(true)
-                .virusDriverLikelihoodType(VirusLikelihoodType.UNKNOWN)
+                .driverLikelihood(VirusLikelihoodType.UNKNOWN)
                 .build());
 
-        Set<AnnotatedVirus> allViruses = Sets.newHashSet();
+        Set<VirusInterpreterEntry> allViruses = Sets.newHashSet();
         allViruses.addAll(reportableViruses);
         allViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(false)
                 .interpretation(VirusInterpretation.EBV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .build());
         allViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(false)
                 .interpretation(VirusInterpretation.EBV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .build());
         allViruses.add(TestVirusInterpreterFactory.builder()
                 .reported(false)
-                .virusDriverLikelihoodType(VirusLikelihoodType.UNKNOWN)
+                .driverLikelihood(VirusLikelihoodType.UNKNOWN)
                 .build());
 
         return ImmutableVirusInterpreterData.builder().reportableViruses(reportableViruses).allViruses(allViruses).build();

--- a/protect/src/test/java/com/hartwig/oncoact/protect/evidence/WildTypeEvidenceTest.java
+++ b/protect/src/test/java/com/hartwig/oncoact/protect/evidence/WildTypeEvidenceTest.java
@@ -7,16 +7,16 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.hartwig.oncoact.drivergene.DriverGene;
-import com.hartwig.oncoact.drivergene.TestDriverGeneFactory;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
-import com.hartwig.oncoact.orange.linx.TestLinxFactory;
-import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
+import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
+import com.hartwig.oncoact.drivergene.DriverGene;
+import com.hartwig.oncoact.drivergene.TestDriverGeneFactory;
+import com.hartwig.oncoact.orange.linx.TestLinxFactory;
 import com.hartwig.oncoact.orange.purple.TestPurpleFactory;
 import com.hartwig.oncoact.protect.ProtectEvidence;
 import com.hartwig.oncoact.protect.TestServeFactory;
@@ -49,8 +49,8 @@ public class WildTypeEvidenceTest {
         LinxFusion reportedFusionMatch = createFusion("BAG4", "FGFR1");
         Set<LinxFusion> reportableFusions = Sets.newHashSet(reportedFusionMatch);
 
-        HomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
-        Set<HomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
+        LinxHomozygousDisruption homozygousDisruption = createHomozygousDisruption("NRAS");
+        Set<LinxHomozygousDisruption> homozygousDisruptions = Sets.newHashSet(homozygousDisruption);
 
         LinxBreakend breakend = TestLinxFactory.breakendBuilder().gene("MYC").build();
         Set<LinxBreakend> breakends = Sets.newHashSet(breakend);
@@ -200,7 +200,7 @@ public class WildTypeEvidenceTest {
     }
 
     @NotNull
-    private static HomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
+    private static LinxHomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
         return TestLinxFactory.homozygousDisruptionBuilder().gene(gene).build();
     }
 

--- a/rose/src/main/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgo.java
+++ b/rose/src/main/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgo.java
@@ -1,5 +1,7 @@
 package com.hartwig.oncoact.rose.conclusion;
 
+import static com.hartwig.oncoact.purple.QcInterpretation.containsTumorCells;
+
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Collection;
@@ -25,12 +27,9 @@ import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
 import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
-import com.hartwig.hmftools.datamodel.purple.PurpleFit;
-import com.hartwig.hmftools.datamodel.purple.PurpleFittedPurityMethod;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleLossOfHeterozygosity;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
-import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleRecord;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
@@ -571,10 +570,5 @@ public final class ConclusionAlgo {
     private static DecimalFormat decimalFormat(@NotNull String format) {
         // To make sure every decimal format uses a dot as separator rather than a comma.
         return new DecimalFormat(format, DecimalFormatSymbols.getInstance(Locale.ENGLISH));
-    }
-
-    private static boolean containsTumorCells(@NotNull PurpleFit purpleFit) {
-        return purpleFit.fittedPurityMethod() != PurpleFittedPurityMethod.NO_TUMOR
-                && !purpleFit.qc().status().contains(PurpleQCStatus.FAIL_NO_TUMOR);
     }
 }

--- a/rose/src/main/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgo.java
+++ b/rose/src/main/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgo.java
@@ -25,9 +25,12 @@ import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
 import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
+import com.hartwig.hmftools.datamodel.purple.PurpleFit;
+import com.hartwig.hmftools.datamodel.purple.PurpleFittedPurityMethod;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleLossOfHeterozygosity;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
+import com.hartwig.hmftools.datamodel.purple.PurpleQCStatus;
 import com.hartwig.hmftools.datamodel.purple.PurpleRecord;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
@@ -112,7 +115,7 @@ public final class ConclusionAlgo {
 
         CuppaPrediction bestPrediction = bestPrediction(rose.orange().cuppa());
 
-        generatePurityConclusion(conclusion, purple.fit().purity(), containsTumorCells(purple), actionabilityMap);
+        generatePurityConclusion(conclusion, purple.fit().purity(), containsTumorCells(purple.fit()), actionabilityMap);
         generateCUPPAConclusion(conclusion, bestPrediction, actionabilityMap);
         generateVariantConclusion(conclusion,
                 reportableVariants,
@@ -122,7 +125,7 @@ public final class ConclusionAlgo {
                 actionable,
                 HRD,
                 rose.orange().chord());
-        generateCNVConclusion(conclusion, reportableGainLosses, actionabilityMap, oncogenic, actionable, containsTumorCells(purple));
+        generateCNVConclusion(conclusion, reportableGainLosses, actionabilityMap, oncogenic, actionable, containsTumorCells(purple.fit()));
         generateFusionConclusion(conclusion, reportableFusions, actionabilityMap, oncogenic, actionable);
         generateHomozygousDisruptionConclusion(conclusion, homozygousDisruptions, actionabilityMap, oncogenic, actionable);
         generateVirusHLAConclusion(conclusion, reportableViruses, lilac, actionabilityMap, oncogenic, actionable);
@@ -570,8 +573,8 @@ public final class ConclusionAlgo {
         return new DecimalFormat(format, DecimalFormatSymbols.getInstance(Locale.ENGLISH));
     }
 
-    private static boolean containsTumorCells(@NotNull PurpleRecord purple) {
-        throw new UnsupportedOperationException("TODO implement");
-//        return purple.fit().containsTumorCells();
+    private static boolean containsTumorCells(@NotNull PurpleFit purpleFit) {
+        return purpleFit.fittedPurityMethod() != PurpleFittedPurityMethod.NO_TUMOR
+                && !purpleFit.qc().status().contains(PurpleQCStatus.FAIL_NO_TUMOR);
     }
 }

--- a/rose/src/test/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgoTest.java
+++ b/rose/src/test/java/com/hartwig/oncoact/rose/conclusion/ConclusionAlgoTest.java
@@ -17,17 +17,17 @@ import com.hartwig.hmftools.datamodel.cuppa.CuppaPrediction;
 import com.hartwig.hmftools.datamodel.hla.ImmutableLilacRecord;
 import com.hartwig.hmftools.datamodel.hla.LilacAllele;
 import com.hartwig.hmftools.datamodel.hla.LilacRecord;
-import com.hartwig.hmftools.datamodel.linx.HomozygousDisruption;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusion;
 import com.hartwig.hmftools.datamodel.linx.LinxFusionType;
+import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption;
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleTranscriptImpact;
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect;
 import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss;
 import com.hartwig.hmftools.datamodel.purple.PurpleMicrosatelliteStatus;
-import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterEntry;
 import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 import com.hartwig.oncoact.clinicaltransript.ClinicalTranscriptModelTestFactory;
 import com.hartwig.oncoact.drivergene.DriverCategory;
@@ -206,7 +206,7 @@ public class ConclusionAlgoTest {
 
     @Test
     public void canGenerateHomozygousDisruptionConclusion() {
-        Set<HomozygousDisruption> homozygousDisruptions =
+        Set<LinxHomozygousDisruption> homozygousDisruptions =
                 Sets.newHashSet(createHomozygousDisruption("PTEN"), createHomozygousDisruption("KRAS"));
         List<String> conclusion = Lists.newArrayList();
         Map<ActionabilityKey, ActionabilityEntry> actionabilityMap =
@@ -226,7 +226,7 @@ public class ConclusionAlgoTest {
 
     @Test
     public void canGenerateVirusOnlyVirusConclusion() {
-        Set<AnnotatedVirus> viruses = createTestVirusInterpreterEntries();
+        Set<VirusInterpreterEntry> viruses = createTestVirusInterpreterEntries();
         List<LilacAllele> alleles = Lists.newArrayList();
         List<String> conclusion = Lists.newArrayList();
         Map<ActionabilityKey, ActionabilityEntry> actionabilityMap =
@@ -243,7 +243,7 @@ public class ConclusionAlgoTest {
 
     @Test
     public void canGenerateHLAOnlyConclusion() {
-        Set<AnnotatedVirus> viruses = Sets.newHashSet();
+        Set<VirusInterpreterEntry> viruses = Sets.newHashSet();
         List<LilacAllele> alleles = createTestLilacRecord().alleles();
         List<String> conclusion = Lists.newArrayList();
         Map<ActionabilityKey, ActionabilityEntry> actionabilityMap =
@@ -257,7 +257,7 @@ public class ConclusionAlgoTest {
 
     @Test
     public void canGenerateHLAVirusBothConclusion() {
-        Set<AnnotatedVirus> viruses = createTestVirusInterpreterEntries();
+        Set<VirusInterpreterEntry> viruses = createTestVirusInterpreterEntries();
         List<LilacAllele> alleles = createTestLilacRecord().alleles();
         List<String> conclusion = Lists.newArrayList();
         Map<ActionabilityKey, ActionabilityEntry> actionabilityMap =
@@ -520,7 +520,7 @@ public class ConclusionAlgoTest {
                         .hgvsCodingImpact("c.172C>T")
                         .hgvsProteinImpact("p.Arg59*")
                         .transcript("transcript2")
-                        .spliceRegion(false)
+                        .inSpliceRegion(false)
                         .effects(Sets.newHashSet())
                         .codingEffect(PurpleCodingEffect.MISSENSE)
                         .build())
@@ -539,7 +539,7 @@ public class ConclusionAlgoTest {
                         .hgvsCodingImpact("c.1723C>T")
                         .hgvsProteinImpact("p.Arg59*")
                         .transcript("transcript2")
-                        .spliceRegion(false)
+                        .inSpliceRegion(false)
                         .effects(Sets.newHashSet())
                         .codingEffect(PurpleCodingEffect.MISSENSE)
                         .build())
@@ -591,19 +591,19 @@ public class ConclusionAlgoTest {
     }
 
     @NotNull
-    private static Set<AnnotatedVirus> createTestVirusInterpreterEntries() {
-        Set<AnnotatedVirus> virusEntries = Sets.newHashSet();
-        AnnotatedVirus virus1 = TestVirusInterpreterFactory.builder()
+    private static Set<VirusInterpreterEntry> createTestVirusInterpreterEntries() {
+        Set<VirusInterpreterEntry> virusEntries = Sets.newHashSet();
+        VirusInterpreterEntry virus1 = TestVirusInterpreterFactory.builder()
                 .interpretation(VirusInterpretation.EBV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.LOW)
+                .driverLikelihood(VirusLikelihoodType.LOW)
                 .build();
-        AnnotatedVirus virus2 = TestVirusInterpreterFactory.builder()
+        VirusInterpreterEntry virus2 = TestVirusInterpreterFactory.builder()
                 .interpretation(VirusInterpretation.HPV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .build();
-        AnnotatedVirus virus3 = TestVirusInterpreterFactory.builder()
+        VirusInterpreterEntry virus3 = TestVirusInterpreterFactory.builder()
                 .interpretation(VirusInterpretation.MCV)
-                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .driverLikelihood(VirusLikelihoodType.HIGH)
                 .build();
 
         virusEntries.add(virus1);
@@ -631,7 +631,7 @@ public class ConclusionAlgoTest {
     }
 
     @NotNull
-    private static HomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
+    private static LinxHomozygousDisruption createHomozygousDisruption(@NotNull String gene) {
         return TestLinxFactory.homozygousDisruptionBuilder().gene(gene).build();
     }
 


### PR DESCRIPTION

* Updates dependency on orange-datamodel from 1.3.3 to 2.3.0
* Various updates to reflect changes to datamodel attributes: HomozygousDisruption -> LinxHomozygousDisruption, etc 
* Updated orange.json files in test resources to use version from hmftools/orange-datamodel

A few notes:
* LinxFusion.display() now formats fusions as "geneStart::geneEnd", small formatting change that can show up in output
* The model no longer has PurpleFit methods hasSufficientQuality() and containsTumorCells(). These are now determined from PurpleFit, implemented in a helper class in oncoact/common
* There is some refactoring implied in the existing code for ReportableVariant/PurpleVariant which previously shared a Variant interface that has been removed. To expedite the update I duplicated (!!) code in protect/evidence/VariantEvidence. However this should be properly refactored, I suspect there's a plan somewhere for how this should be organized but didn't find it in Jira and not sure what it is.

So apart from the VariantEvidence cleanup remaining for the future, the code is ported and unit tests pass. Hope that's enough to move forward for now. Validation testing on proper data of course should be done.